### PR TITLE
bugfix:add clusterfile to all image whatever build type is

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -6,8 +6,8 @@ type Interface interface {
 	Build(name string, context string, kubefileName string) error
 }
 
-func NewBuilder(config *Config, builderType string) (Interface, error) {
-	if builderType == common.LocalBuild {
+func NewBuilder(config *Config) (Interface, error) {
+	if config.BuildType == common.LocalBuild {
 		return NewLocalBuilder(config)
 	}
 	return NewCloudBuilder(config)

--- a/build/local_builder.go
+++ b/build/local_builder.go
@@ -23,6 +23,7 @@ import (
 )
 
 type Config struct {
+	BuildType string
 }
 
 // LocalBuilder: local builder using local provider to build a cluster image
@@ -276,23 +277,11 @@ func (l *LocalBuilder) ApplyCluster() error {
 }
 
 func (l *LocalBuilder) UpdateImageMetadata() error {
+	l.setClusterFileToImage()
 	if err := l.squashBaseImageLayerIntoCurrentImage(); err != nil {
 		return err
 	}
-	// write image info to its metadata
 	filename := fmt.Sprintf("%s/%s%s", common.DefaultImageMetaRootDir, l.Image.Spec.ID, common.YamlSuffix)
-	//set cluster file
-	if utils.IsFileExist(common.RawClusterfile) {
-		bytes, err := ioutil.ReadFile(common.RawClusterfile)
-		if err != nil {
-			return err
-		}
-		if l.Image.Annotations == nil {
-			l.Image.Annotations = make(map[string]string)
-		}
-		l.Image.Annotations[common.ImageAnnotationForClusterfile] = string(bytes)
-	}
-
 	// save layer ids
 	for _, layer := range l.Image.Spec.Layers {
 		if layer.Hash != "" {
@@ -307,7 +296,7 @@ func (l *LocalBuilder) UpdateImageMetadata() error {
 			}
 		}
 	}
-
+	// write image info to its metadata
 	if err := utils.MarshalYamlToFile(filename, l.Image); err != nil {
 		return fmt.Errorf("failed to write image yaml:%v", err)
 	}
@@ -322,6 +311,65 @@ func (l *LocalBuilder) UpdateImageMetadata() error {
 	logger.Info("update image %s to image metadata success !", l.ImageName)
 
 	return nil
+}
+
+// setClusterFileToImage: set cluster file whatever build type is
+func (l *LocalBuilder) setClusterFileToImage() {
+	var clusterFileData string
+	if utils.IsFileExist(common.RawClusterfile) {
+		bytes, err := utils.ReadAll(common.RawClusterfile)
+		if err != nil {
+			logger.Warn("failed to set cluster file to image metadata,%s not exist", common.RawClusterfile)
+		}
+		clusterFileData = string(bytes)
+	} else {
+		clusterFileData = l.GetRawClusterFile()
+	}
+
+	l.addImageAnnotations(common.ImageAnnotationForClusterfile, clusterFileData)
+}
+
+// GetClusterFile from user build context or from base image
+func (l *LocalBuilder) GetRawClusterFile() string {
+	if l.Image.Spec.Layers[0].Value == common.ImageScratch {
+		data, err := ioutil.ReadFile(filepath.Join("etc", common.DefaultClusterFileName))
+		if err != nil {
+			return ""
+		}
+		return string(data)
+	}
+	// find cluster file from context
+	if clusterFile := l.getClusterFileFromContext(); clusterFile != nil {
+		logger.Info("get cluster file from context success!")
+		return string(clusterFile)
+	}
+	// find cluster file from base image
+	clusterFile := image.GetClusterFileFromImage(l.Image.Spec.Layers[0].Value)
+	if clusterFile != "" {
+		logger.Info("get cluster file from base image success!")
+		return clusterFile
+	}
+	return ""
+}
+
+func (l *LocalBuilder) getClusterFileFromContext() []byte {
+	for i := range l.Image.Spec.Layers {
+		layer := l.Image.Spec.Layers[i]
+		if layer.Type == common.COPYCOMMAND && strings.Fields(layer.Value)[0] == common.DefaultClusterFileName {
+			if clusterFile, _ := utils.ReadAll(strings.Fields(layer.Value)[0]); clusterFile != nil {
+				return clusterFile
+			}
+		}
+	}
+	return nil
+}
+
+// GetClusterFile from user build context or from base image
+func (l *LocalBuilder) addImageAnnotations(key, value string) {
+	if l.Image.Annotations == nil {
+		l.Image.Annotations = make(map[string]string)
+	}
+	l.Image.Annotations[key] = value
 }
 
 func (l *LocalBuilder) PushToRegistry() error {

--- a/build/testing/cloud_builder_test.go
+++ b/build/testing/cloud_builder_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestCloudBuilder_Build(t *testing.T) {
 	conf := &build.Config{}
-	builder, err := build.NewBuilder(conf, "")
+	builder, err := build.NewBuilder(conf)
 	if err != nil {
 		t.Error(err)
 	}

--- a/build/testing/local_builder_test.go
+++ b/build/testing/local_builder_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestLocalBuilder_Build(t *testing.T) {
-	conf := &build.Config{}
-	builder, err := build.NewBuilder(conf, common.LocalBuild)
+	conf := &build.Config{BuildType: common.LocalBuild}
+	builder, err := build.NewBuilder(conf)
 	if err != nil {
 		t.Error(err)
 	}

--- a/sealer/cmd/build.go
+++ b/sealer/cmd/build.go
@@ -38,8 +38,10 @@ var buildCmd = &cobra.Command{
 	Short:   "cloud image local build command line",
 	Example: `sealer build -f Kubefile -t my-kubernetes:1.18.3 .`,
 	Run: func(cmd *cobra.Command, args []string) {
-		conf := &build.Config{}
-		builder, err := build.NewBuilder(conf, buildConfig.BuildType)
+		conf := &build.Config{
+			BuildType: buildConfig.BuildType,
+		}
+		builder, err := build.NewBuilder(conf)
 		if err != nil {
 			logger.Error(err)
 			os.Exit(1)

--- a/seautil/cmd/build.go
+++ b/seautil/cmd/build.go
@@ -41,8 +41,10 @@ var buildCmd = &cobra.Command{
 	Short: "cloud image local build command line",
 	Long:  `seautil build -f Kubefile -t my-kubernetes:1.18.3 . `,
 	Run: func(cmd *cobra.Command, args []string) {
-		conf := &build.Config{}
-		builder, err := build.NewBuilder(conf, buildConfig.BuildType)
+		conf := &build.Config{
+			BuildType: buildConfig.BuildType,
+		}
+		builder, err := build.NewBuilder(conf)
 		if err != nil {
 			logger.Error(err)
 			os.Exit(-1)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
support to add clusterfile to all image whatever build type is

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes  #107
### Describe how you did it

local build : find cluster file from kubefile, image matadata,rootfs .

cloud build : first find clusterfile from its applied, if not exist ,find it from local build steps.

if base image  is scratch, then read clusterfile from etc/Clusterfile
### Describe how to verify it
run local build: sealer build -f Kubefile -t {your image name } -b local .
run cloud build :  sealer build -f Kubefile -t {your image name } .
run build rootfs : from  scratch 

### Special notes for reviews
