### PR TITLE
refactor:print ssh cmd output when exec failed

### DIFF
--- a/utils/ssh/sshcmd.go
+++ b/utils/ssh/sshcmd.go
@@ -85,7 +85,8 @@ func (s *SSH) Cmd(host, cmd string) ([]byte, error) {
 	defer session.Close()
 	b, err := session.CombinedOutput(cmd)
 	if err != nil {
-		return nil, fmt.Errorf("[ssh][%s]run command failed [%s], %v", host, cmd, err)
+		fmt.Printf("[ssh][%s]failed to run command [%s],output is: %s", host, cmd, b)
+		return nil, fmt.Errorf("[ssh][%s]run command failed [%s]", host, cmd)
 	}
 	return b, nil
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
there are many diffrent situations when we run command remotely. so we need to print "SSH.cmd" output to make log meassage more readable .

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

printf output of this function:  session.CombinedOutput(cmd)

### Describe how to verify it
![image](https://user-images.githubusercontent.com/83740799/118933333-a5e07a00-b97b-11eb-9322-6e34db331e6f.png)


### Special notes for reviews
