### PR TITLE
fix(main): more master replace error

### DIFF
--- a/runtime/masters.go
+++ b/runtime/masters.go
@@ -137,7 +137,7 @@ func (d *Default) sendFileToHosts(Hosts []string, src, dst string) {
 
 func (d *Default) ReplaceKubeConfigV1991V1992(masters []string) bool {
 	// fix > 1.19.1 kube-controller-manager and kube-scheduler use the LocalAPIEndpoint instead of the ControlPlaneEndpoint.
-	if VersionCompare(d.Metadata.Version, V1991) && VersionCompare(V1992, d.Metadata.Version) {
+	if d.Metadata.Version == V1991 || d.Metadata.Version == V1992 {
 		for _, v := range masters {
 			ip := utils.GetHostIP(v)
 			cmd := fmt.Sprintf(RemoteReplaceKubeConfig, KUBESCHEDULERCONFIGFILE, ip, KUBECONTROLLERCONFIGFILE, ip, KUBESCHEDULERCONFIGFILE)
@@ -292,7 +292,7 @@ func (d *Default) joinMasters(masters []string) error {
 	if err := d.LinkStaticFiles(masters); err != nil {
 		return err
 	}
-	d.SendJoinMasterKubeConfigs(masters)
+	d.SendJoinMasterKubeConfigs(masters, AdminConf, ControllerConf, SchedulerConf)
 	// TODO only needs send ca?
 	d.sendNewCertAndKey(masters)
 	d.sendJoinCPConfig(masters)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

more master 

```
2021-05-20 17:49:05 [INFO] [ssh][192.168.64.12] : grep -qF "apiserver.cluster.local" /etc/kubernetes/scheduler.conf  && sed -i 's/apiserver.cluster.local/192.168.64.12/' /etc/kubernetes/controller-manager.conf && sed -i 's/apiserver.cluster.local/192.168.64.12/' /etc/kubernetes/scheduler.conf
grep: /etc/kubernetes/scheduler.conf: No such file or directory
2021-05-20 17:49:05 [EROR] exec command failed Process exited with status 2
```

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
