### PR TITLE
fix hash of tar diff

### DIFF
--- a/utils/compress/compress.go
+++ b/utils/compress/compress.go
@@ -120,6 +120,12 @@ func writeToTarWriter(dir, newFolder string, tarWriter *tar.Writer) error {
 			header.Name = filepath.Join(newFolder, filepath.Base(dir))
 		}
 
+		// those two fields may diff in different machine,
+		// so we hardcoded the gname and uname to make hash of
+		// tar consistent
+		// TODO think of a better way to fix this issue
+		header.Gname = "root"
+		header.Uname = "root"
 		// write header
 		if walkErr = tarWriter.WriteHeader(header); walkErr != nil {
 			return walkErr


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
hash of tar contains many header info, so hash will change in different machine, so I hardcode the gname and uname for the file header to avoid this problem.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #151 
### Describe how you did it


### Describe how to verify it


### Special notes for reviews
this is just a temp solution. A better layer arch is more needed.