### PR TITLE
fix: duplicated certSANS in generated kubeadm config file

### DIFF
--- a/runtime/kubeadm.go
+++ b/runtime/kubeadm.go
@@ -45,7 +45,13 @@ func (d *Default) templateFromContent(templateContent string) ([]byte, error) {
 	}
 
 	var envMap = make(map[string]interface{})
-	envMap[CertSANS] = d.APIServerCertSANs
+	sans := []string{"127.0.0.1"}
+	sans = utils.AppendIPList(sans, []string{d.APIServer})
+	sans = utils.AppendIPList(sans, d.Masters)
+	sans = utils.AppendIPList(sans, d.APIServerCertSANs)
+	sans = utils.AppendIPList(sans, []string{d.VIP})
+
+	envMap[CertSANS] = sans
 	envMap[VIP] = d.VIP
 	envMap[Masters] = utils.GetHostIPSlice(d.Masters)
 	envMap[Version] = d.Metadata.Version

--- a/runtime/template.go
+++ b/runtime/template.go
@@ -26,15 +26,9 @@ networking:
   serviceSubnet: {{.SvcCIDR}}
 apiServer:
   certSANs:
-  - 127.0.0.1
-  - {{.ApiServer}}
-  {{range .Masters -}}
-  - {{.}}
-  {{end -}}
   {{range .CertSANS -}}
   - {{.}}
   {{end -}}
-  - {{.VIP}}
   extraArgs:
     etcd-servers: {{.EtcdServers}}
     feature-gates: TTLAfterFinished=true,EphemeralContainers=true
@@ -119,15 +113,9 @@ networking:
   serviceSubnet: {{.SvcCIDR}}
 apiServer:
   certSANs:
-  - 127.0.0.1
-  - {{.ApiServer}}
-  {{range .Masters -}}
-  - {{.}}
-  {{end -}}
   {{range .CertSANS -}}
   - {{.}}
   {{end -}}
-  - {{.VIP}}
   extraArgs:
     etcd-servers: {{.EtcdServers}}
     feature-gates: TTLAfterFinished=true,EphemeralContainers=true


### PR DESCRIPTION
### Describe what this PR does / why we need it

fix duplicated certSANS in generated kubeadm config file

### Does this pull request fix one issue?

Fixes #220 

### Describe how you did it

Using `utils.AppendIPList` to append all IP address into a single slice for `CertSANS` of env map, 
so we can prevent duplicated IP.
