### PR TITLE
Feature/buildcache

### DIFF
--- a/build/const.go
+++ b/build/const.go
@@ -1,0 +1,22 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import "github.com/alibaba/sealer/common"
+
+const (
+	cacheID      = common.CacheID
+	maxLayerDeep = 128
+)

--- a/build/context.go
+++ b/build/context.go
@@ -60,3 +60,7 @@ func (c *CloudBuilder) sendBuildContext() (err error) {
 	logger.Info("send build context to %s success !", c.RemoteHostIP)
 	return nil
 }
+
+func (c *CloudBuilder) changeBuilderContext() {
+	c.local.Context = "."
+}

--- a/build/testing/kubefile
+++ b/build/testing/kubefile
@@ -1,5 +1,4 @@
-FROM sealer/my-kuberentes-cluster-with-dashboard:latest
+FROM registry.cn-qingdao.aliyuncs.com/sealer-io/kubernetes:v1.19.9.alpha.3
 COPY Clusterfile etc
 COPY dashboard.yaml .
-RUN wget helm.sh/helm
 CMD touch mytest

--- a/common/common.go
+++ b/common/common.go
@@ -51,6 +51,7 @@ const (
 	RemoteSealerPath              = "/usr/local/bin/sealer"
 	DefaultCloudProvider          = AliCloud
 	ClusterfileName               = "ClusterfileName"
+	CacheID                       = "cacheID"
 )
 
 // image module

--- a/config/config.go
+++ b/config/config.go
@@ -1,3 +1,17 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/config/test_clusterfile.yaml
+++ b/config/test_clusterfile.yaml
@@ -1,3 +1,17 @@
+# Copyright © 2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: sealer.aliyun.com/v1alpha1
 kind: Cluster
 metadata:

--- a/image/cache.go
+++ b/image/cache.go
@@ -1,0 +1,39 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package image
+
+import (
+	"fmt"
+
+	"github.com/alibaba/sealer/image/cache"
+	"github.com/alibaba/sealer/image/store"
+)
+
+func (d DefaultImageService) BuildImageCache() (Cache, error) {
+	ls, err := store.NewDefaultLayerStore()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build image cache, err: %s", err)
+	}
+	fs, err := store.NewFSStoreBackend()
+	if err != nil {
+		return nil, fmt.Errorf("failed to init store backend for image cache, err: %s", err)
+	}
+	imageStore, err := cache.NewImageStore(fs, ls)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init image store for image cache, err: %s", err)
+	}
+
+	return cache.NewLocalImageCache(imageStore)
+}

--- a/image/cache/cache.go
+++ b/image/cache/cache.go
@@ -1,0 +1,60 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"fmt"
+
+	"github.com/opencontainers/go-digest"
+
+	v1 "github.com/alibaba/sealer/types/api/v1"
+	"github.com/pkg/errors"
+)
+
+//LocalImageCache saves all the layer
+type LocalImageCache struct {
+	chainStore ChainStore
+}
+
+type NopImageCache struct {
+}
+
+func NewLocalImageCache(chainStore ChainStore) (*LocalImageCache, error) {
+	return &LocalImageCache{
+		chainStore: chainStore,
+	}, nil
+}
+
+func (NopImageCache) GetCache(parentID string, layer *Layer) (layerID digest.Digest, err error) {
+	return "", errors.Errorf("nop cache")
+}
+
+func (lic *LocalImageCache) GetCache(parentID string, layer *Layer) (layerID digest.Digest, err error) {
+	curChainID, err := layer.ChainID(ChainID(parentID))
+	if err != nil {
+		return "", fmt.Errorf("failed to get cur chain id, err: %s", err)
+	}
+
+	tmpLayer, err := getLocalCachedImage(lic.chainStore, curChainID)
+	if err != nil {
+		return "", err
+	}
+
+	return tmpLayer.ID, nil
+}
+
+func getLocalCachedImage(imageChain ChainStore, layerChainID ChainID) (v1.Layer, error) {
+	return imageChain.GetChainLayer(layerChainID)
+}

--- a/image/cache/chain.go
+++ b/image/cache/chain.go
@@ -1,0 +1,210 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"sync"
+
+	"github.com/alibaba/sealer/common"
+
+	"github.com/alibaba/sealer/image/store"
+
+	"github.com/alibaba/sealer/logger"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+
+	v1 "github.com/alibaba/sealer/types/api/v1"
+	"github.com/opencontainers/go-digest"
+)
+
+var imageChain *chainStore
+var once sync.Once
+
+//ChainID is caculated from a series of serialized cache layers. The layers cacheID
+// is "", but the COPY layer.
+// same ChainID indicates that same entire file system.
+type ChainID digest.Digest
+
+func (id ChainID) String() string {
+	return id.Digest().String()
+}
+
+// Digest converts ID into a digest
+func (id ChainID) Digest() digest.Digest {
+	return digest.Digest(id)
+}
+
+type ImageID digest.Digest
+
+func (id ImageID) String() string {
+	return id.Digest().String()
+}
+
+// Digest converts ID into a digest
+func (id ImageID) Digest() digest.Digest {
+	return digest.Digest(id)
+}
+
+// ChainStore is an interface for manipulating images
+type ChainStore interface {
+	Images() map[ImageID]*v1.Image
+	GetChainLayer(id ChainID) (v1.Layer, error)
+}
+
+type chainItem struct {
+	layer   v1.Layer
+	chainID ChainID
+	parent  *chainItem
+}
+
+type chainStore struct {
+	sync.RWMutex
+	chains map[ChainID]*chainItem
+	fs     store.Backend
+	ls     store.LayerStore
+}
+
+func NewImageStore(fs store.Backend, ls store.LayerStore) (ChainStore, error) {
+	once.Do(func() {
+		imageChain = &chainStore{
+			chains: make(map[ChainID]*chainItem),
+			fs:     fs,
+			ls:     ls,
+		}
+
+		if err := imageChain.restore(); err != nil {
+			return
+		}
+	})
+	return imageChain, nil
+}
+
+// restore reads all images saved in filesystem and calculate their chainID
+func (cs *chainStore) restore() error {
+	cs.Lock()
+	defer cs.Unlock()
+
+	//read all image layers
+	images := cs.Images()
+	for _, image := range images {
+		layers := image.Spec.Layers
+		var lastChainItem *chainItem = &chainItem{}
+		for _, layer := range layers {
+			var (
+				chainID ChainID
+				err     error
+			)
+
+			cacheLayer, err := cs.newCacheLayer(&layer)
+			if err != nil {
+				logger.Warn("failed to new a cache layer for %v, err: %s", layer, err)
+				continue
+			}
+
+			// first chainItem's parent chainID is empty
+			chainID, err = cacheLayer.ChainID(lastChainItem.chainID)
+			if err != nil {
+				logger.Error(err)
+				break
+			}
+
+			_, ok := cs.chains[chainID]
+			if !ok {
+				cItem := &chainItem{
+					layer:   layer,
+					parent:  lastChainItem,
+					chainID: chainID,
+				}
+				cs.chains[chainID] = cItem
+			}
+			lastChainItem = &chainItem{
+				layer:   layer,
+				parent:  lastChainItem,
+				chainID: chainID,
+			}
+		}
+	}
+
+	return nil
+}
+
+func (cs *chainStore) GetChainLayer(id ChainID) (v1.Layer, error) {
+	cs.RLock()
+	defer cs.RUnlock()
+
+	if imagemeta, ok := cs.chains[id]; ok {
+		return imagemeta.layer, nil
+	}
+
+	return v1.Layer{}, errors.Errorf("no layer for chain id %s in file system", id)
+}
+
+func (cs *chainStore) Images() map[ImageID]*v1.Image {
+	var (
+		images  map[ImageID]*v1.Image
+		configs [][]byte
+		err     error
+	)
+
+	images = make(map[ImageID]*v1.Image)
+	configs, err = cs.fs.ListImages()
+	if err != nil {
+		logger.Error("failed to get images from file system, err: %v", err)
+		return nil
+	}
+	for _, config := range configs {
+		img := &v1.Image{}
+		err = yaml.Unmarshal(config, img)
+		if err != nil {
+			logger.Error("failed to unmarshal bytes into image")
+			continue
+		}
+		dgst := digest.FromBytes(config)
+		images[ImageID(dgst)] = img
+	}
+
+	return images
+}
+
+func (cs *chainStore) newCacheLayer(layer *v1.Layer) (*Layer, error) {
+	var cacheLayer = Layer{Type: layer.Type, Value: layer.Value}
+	// only copy layer needs the cache id.
+	if layer.Type != common.COPYCOMMAND {
+		return &cacheLayer, nil
+	}
+
+	cacheIDBytes, err := cs.fs.GetMetadata(layer.ID, common.CacheID)
+	if err != nil {
+		return nil, err
+	}
+	// TODO maybe we should validate the cacheid over digest
+	cacheLayer.CacheID = string(cacheIDBytes)
+	return &cacheLayer, nil
+}
+
+func CalculateCacheID(cacheLayers []Layer) (ChainID, error) {
+	var parentID ChainID
+	var err error
+
+	for _, l := range cacheLayers {
+		parentID, err = l.ChainID(parentID)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return parentID, nil
+}

--- a/image/cache/layer.go
+++ b/image/cache/layer.go
@@ -1,0 +1,41 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"strings"
+
+	"github.com/opencontainers/go-digest"
+)
+
+type Layer struct {
+	// cacheID for layerdb/layersid/cacheID, we will load the content only for COPY layer
+	CacheID string `json:"cache_id"`
+	// same as v1Layer type
+	Type string `json:"type"`
+	// same as v1Layer value
+	Value string `json:"value"`
+}
+
+func (l *Layer) String() string {
+	return strings.TrimSpace(l.CacheID) + ":" + strings.TrimSpace(l.Type) + ":" + strings.TrimSpace(l.Value)
+}
+
+func (l *Layer) ChainID(parentID ChainID) (ChainID, error) {
+	if parentID.String() == "" {
+		return ChainID(digest.FromString(l.String())), nil
+	}
+	return ChainID(digest.FromString(parentID.String() + ":" + l.String())), nil
+}

--- a/image/cache/service.go
+++ b/image/cache/service.go
@@ -1,0 +1,52 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"fmt"
+
+	v1 "github.com/alibaba/sealer/types/api/v1"
+	"github.com/opencontainers/go-digest"
+)
+
+type Service interface {
+	NewCacheLayer(layer v1.Layer, cacheID digest.Digest) Layer
+
+	CalculateChainID(layers interface{}) (ChainID, error)
+}
+
+type service struct {
+}
+
+func (s *service) NewCacheLayer(layer v1.Layer, cacheID digest.Digest) Layer {
+	return Layer{
+		CacheID: cacheID.String(),
+		Type:    layer.Type,
+		Value:   layer.Value,
+	}
+}
+
+func (s *service) CalculateChainID(layers interface{}) (ChainID, error) {
+	switch ls := layers.(type) {
+	case []Layer:
+		return CalculateCacheID(ls)
+	default:
+		return "", fmt.Errorf("do not support calculate chain ID on %v", ls)
+	}
+}
+
+func NewService() (Service, error) {
+	return &service{}, nil
+}

--- a/image/image_interface.go
+++ b/image/image_interface.go
@@ -43,8 +43,9 @@ type Service interface {
 	Push(imageName string) error
 	Delete(imageName string) error
 	Login(RegistryURL, RegistryUsername, RegistryPasswd string) error
+	CacheBuilder
 }
 
 type LayerService interface {
-	LayerStorage() store.LayerStorage
+	LayerStore() store.LayerStore
 }

--- a/image/imagecache_interface.go
+++ b/image/imagecache_interface.go
@@ -14,18 +14,15 @@
 
 package image
 
-import "github.com/alibaba/sealer/image/store"
+import (
+	"github.com/alibaba/sealer/image/cache"
+	"github.com/opencontainers/go-digest"
+)
 
-type DefaultLayerService struct {
-	layerStorage store.LayerStorage
+type CacheBuilder interface {
+	BuildImageCache() (Cache, error)
 }
 
-func (dls DefaultLayerService) LayerStorage() store.LayerStorage {
-	return dls.layerStorage
-}
-
-func NewLayerService() LayerService {
-	return DefaultLayerService{
-		layerStorage: store.NewDefaultLayerStorage(),
-	}
+type Cache interface {
+	GetCache(parentID string, layer *cache.Layer) (LayerID digest.Digest, err error)
 }

--- a/image/imageprobe.go
+++ b/image/imageprobe.go
@@ -1,0 +1,77 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package image
+
+import (
+	"fmt"
+
+	"github.com/alibaba/sealer/image/cache"
+	"github.com/alibaba/sealer/logger"
+	"github.com/opencontainers/go-digest"
+)
+
+type Prober interface {
+	Reset()
+	Probe(parentID string, layer *cache.Layer) (cacheID digest.Digest, err error)
+}
+
+type imageProber struct {
+	cache       Cache
+	reset       func() Cache
+	cacheBusted bool
+}
+
+func NewImageProber(cacheBuilder CacheBuilder, noCache bool) Prober {
+	if noCache {
+		return &nopProber{}
+	}
+
+	reset := func() Cache {
+		c, err := cacheBuilder.BuildImageCache()
+		if err != nil {
+			logger.Info("failed to init image cache, err: %s", err)
+			return &cache.NopImageCache{}
+		}
+		return c
+	}
+
+	return &imageProber{cache: reset(), reset: reset}
+}
+
+func (c *imageProber) Reset() {
+	c.cache = c.reset()
+	c.cacheBusted = false
+}
+
+func (c *imageProber) Probe(parentID string, layer *cache.Layer) (cacheID digest.Digest, err error) {
+	if c.cacheBusted {
+		return "", nil
+	}
+
+	cacheID, err = c.cache.GetCache(parentID, layer)
+	if err != nil {
+		return "", err
+	}
+
+	return cacheID, nil
+}
+
+type nopProber struct{}
+
+func (c *nopProber) Reset() {}
+
+func (c *nopProber) Probe(_ string, _ *cache.Layer) (digest.Digest, error) {
+	return "", fmt.Errorf("nop prober")
+}

--- a/image/store/distribution.go
+++ b/image/store/distribution.go
@@ -33,9 +33,9 @@ type DistributionMetadataItem struct {
 // which indicate that digest of compressedlayerStream in specific registry and repository
 type DistributionMetadata []DistributionMetadataItem
 
-func (ls LayerStorage) LoadDistributionMetadata(layerID LayerID) (map[string]digest.Digest, error) {
+func (fs *filesystem) LoadDistributionMetadata(layerID LayerID) (map[string]digest.Digest, error) {
 	var (
-		layerDBPath = ls.LayerDBDir(layerID.ToDigest())
+		layerDBPath = fs.LayerDBDir(layerID.ToDigest())
 		metadatas   = DistributionMetadata{}
 		res         = map[string]digest.Digest{}
 	)
@@ -57,9 +57,9 @@ func (ls LayerStorage) LoadDistributionMetadata(layerID LayerID) (map[string]dig
 	return res, nil
 }
 
-func (ls LayerStorage) addDistributionMetadata(layerID LayerID, newMetadatas map[string]digest.Digest) error {
+func (fs *filesystem) addDistributionMetadata(layerID LayerID, newMetadatas map[string]digest.Digest) error {
 	// load from distribution_layer_digest
-	metadataMap, err := ls.LoadDistributionMetadata(layerID)
+	metadataMap, err := fs.LoadDistributionMetadata(layerID)
 	if err != nil {
 		return err
 	}
@@ -81,5 +81,5 @@ func (ls LayerStorage) addDistributionMetadata(layerID LayerID, newMetadatas map
 		return err
 	}
 
-	return utils.WriteFile(filepath.Join(ls.LayerDBDir(layerID.ToDigest()), "distribution_layer_digest"), distributionMetadatasJSON)
+	return utils.WriteFile(filepath.Join(fs.LayerDBDir(layerID.ToDigest()), "distribution_layer_digest"), distributionMetadatasJSON)
 }

--- a/image/store/filesystem.go
+++ b/image/store/filesystem.go
@@ -22,113 +22,132 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-
-	"github.com/docker/docker/pkg/ioutils"
+	"strings"
+	"sync"
 
 	"github.com/alibaba/sealer/logger"
-
+	"github.com/docker/docker/pkg/ioutils"
 	"github.com/vbatts/tar-split/tar/asm"
 	"github.com/vbatts/tar-split/tar/storage"
 
-	"github.com/alibaba/sealer/utils"
+	"github.com/alibaba/sealer/common"
+	pkgutils "github.com/alibaba/sealer/utils"
+	"github.com/pkg/errors"
 
 	"github.com/opencontainers/go-digest"
 )
 
-type LayerStorage struct {
-	LayerDataRoot string
-	LayerDBRoot   string
+const (
+	imageDBRoot = common.DefaultImageDBRootDir
+)
+
+// Backend is a service for image/layer read and write.
+// is majorly used by layer store.
+// Avoid invoking backend by others as possible as we can.
+type Backend interface {
+	Get(id digest.Digest) ([]byte, error)
+	Set(data []byte) (digest.Digest, error)
+	Delete(id digest.Digest) error
+	ListImages() ([][]byte, error)
+	SetMetadata(id digest.Digest, key string, data []byte) error
+	GetMetadata(id digest.Digest, key string) ([]byte, error)
+	DeleteMetadata(id digest.Digest, key string) error
+	LayerDBDir(digest digest.Digest) string
+	LayerDataDir(digest digest.Digest) string
+	assembleTar(id LayerID, writer io.Writer) error
+	storeROLayer(layer Layer) error
+	loadAllROLayers() ([]*ROLayer, error)
+	addDistributionMetadata(layerID LayerID, newMetadatas map[string]digest.Digest) error
 }
 
-func (ls LayerStorage) LayerDBDir(digest digest.Digest) string {
-	return filepath.Join(ls.LayerDBRoot, digest.Algorithm().String(), digest.Hex())
+type filesystem struct {
+	sync.RWMutex
+	layerDataRoot string
+	layerDBRoot   string
 }
 
-func (ls LayerStorage) LayerDataDir(digest digest.Digest) string {
-	return filepath.Join(ls.LayerDataRoot, digest.Hex())
+func NewFSStoreBackend() (Backend, error) {
+	return &filesystem{
+		layerDataRoot: layerDataRoot,
+		layerDBRoot:   layerDBRoot,
+	}, nil
 }
 
-func (ls LayerStorage) LoadLayerID(layerDBPath string) (LayerID, error) {
-	idBytes, err := ioutil.ReadFile(filepath.Join(layerDBPath, "id"))
-	if err != nil {
-		return "", err
+func metadataDir(v interface{}) string {
+	switch val := v.(type) {
+	case digest.Digest:
+		return filepath.Join(imageDBRoot, val.Hex()+common.YamlSuffix)
+	case string:
+		if strings.Contains(val, common.YamlSuffix) {
+			return filepath.Join(imageDBRoot, val)
+		}
+		return filepath.Join(imageDBRoot, val+common.YamlSuffix)
 	}
-	dig, err := digest.Parse(string(idBytes))
-	if err != nil {
-		return "", err
-	}
-	return LayerID(dig), nil
+
+	return ""
 }
 
-func (LayerStorage) LoadLayerSize(layerDBPath string) (int64, error) {
-	sizeBytes, err := ioutil.ReadFile(filepath.Join(layerDBPath, "size"))
-	if err != nil {
-		return 0, err
-	}
-
-	size, err := strconv.ParseInt(string(sizeBytes), 10, 64)
-	if err != nil {
-		return 0, err
-	}
-	return size, nil
-}
-
-func (ls LayerStorage) loadROLayer(layerDBPath string) (*ROLayer, error) {
-	layerID, err := ls.LoadLayerID(layerDBPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get layer metadata %s, whose id file lost, err: %s", filepath.Base(layerDBPath), err)
-	}
-
-	layerSize, err := ls.LoadLayerSize(layerDBPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read size of layer %s, err: %s", filepath.Base(layerDBPath), err)
-	}
-
-	metadataMap, err := ls.LoadDistributionMetadata(layerID)
-	if err != nil {
-		// we could tolerate the miss of DistributionMetadata.
-		// the consequence is that we push the layer repeatedly
-		logger.Warn("failed to get layer distribution digest, err: %s", filepath.Base(layerDBPath), err)
-	}
-
-	return NewROLayer(
-		layerID.ToDigest(),
-		layerSize,
-		metadataMap,
+func (fs *filesystem) Get(id digest.Digest) ([]byte, error) {
+	var (
+		metadata []byte
+		err      error
 	)
+	fs.RLock()
+	defer fs.RUnlock()
+
+	//we do not use the functions in pkgutils because the validation steps
+	//in its function is redundant in this situation
+	metadata, err = ioutil.ReadFile(metadataDir(id))
+	if err != nil {
+		return nil, errors.Errorf("failed to read image %s's metadata, err: %v", id, err)
+	}
+
+	if digest.FromBytes(metadata) != id {
+		return nil, errors.Errorf("failed to verify image %s's hash value", id)
+	}
+
+	return metadata, nil
 }
 
-func (ls LayerStorage) storeROLayer(layer Layer) error {
-	dig := digest.Digest(layer.ID())
-	dbDir := ls.LayerDBDir(dig)
-	err := utils.WriteFile(filepath.Join(dbDir, "size"), []byte(fmt.Sprintf("%d", layer.Size())))
-	if err != nil {
-		return fmt.Errorf("failed to write size for %s, err: %s", layer.ID(), err)
+func (fs *filesystem) Set(data []byte) (digest.Digest, error) {
+	var (
+		dgst digest.Digest
+		err  error
+	)
+	fs.Lock()
+	defer fs.Unlock()
+
+	if len(data) == 0 {
+		return "", errors.Errorf("invalid empty data")
 	}
 
-	err = ls.addDistributionMetadata(layer.ID(), layer.DistributionMetadata())
-	if err != nil {
-		return fmt.Errorf("failed to write distribution metadata for %s, err: %s", layer.ID(), err)
+	dgst = digest.FromBytes(data)
+	if err = ioutil.WriteFile(metadataDir(dgst), data, common.FileMode0644); err != nil {
+		return "", errors.Errorf("failed to write image %s's metadata, err: %v", dgst, err)
 	}
 
-	err = utils.WriteFile(filepath.Join(dbDir, "id"), []byte(layer.ID()))
-	logger.Debug("writing id %s to %s", layer.ID(), filepath.Join(dbDir, "id"))
-	if err != nil {
-		return fmt.Errorf("failed to write id for %s, err: %s", layer.ID(), err)
+	return dgst, nil
+}
+
+func (fs *filesystem) Delete(dgst digest.Digest) error {
+	var (
+		err error
+	)
+	fs.Lock()
+	defer fs.Unlock()
+
+	if err = os.RemoveAll(metadataDir(dgst)); err != nil {
+		return errors.Errorf("failed to delete image metadata, err: %v", err)
 	}
 
 	return nil
 }
 
-func (ls LayerStorage) assembleTar(id LayerID, writer io.Writer) error {
+func (fs *filesystem) assembleTar(id LayerID, writer io.Writer) error {
 	var (
-		tarDataPath   = filepath.Join(ls.LayerDBDir(digest.Digest(id)), tarDataGZ)
-		layerDataPath = ls.LayerDataDir(digest.Digest(id))
+		tarDataPath   = filepath.Join(fs.LayerDBDir(digest.Digest(id)), tarDataGZ)
+		layerDataPath = fs.LayerDataDir(digest.Digest(id))
 	)
-	_, err := os.Stat(tarDataPath)
-	if err != nil {
-		return fmt.Errorf("failed to find %s for layer %s, err: %s", tarDataGZ, id, err)
-	}
 
 	mf, err := os.Open(tarDataPath)
 	if err != nil {
@@ -152,13 +171,166 @@ func (ls LayerStorage) assembleTar(id LayerID, writer io.Writer) error {
 	return asm.WriteOutputTarStream(fileGetter, metaUnpacker, writer)
 }
 
-func NewLayerStorage(layerDataRoot, layerDBRoot string) LayerStorage {
-	return LayerStorage{
-		LayerDataRoot: layerDataRoot,
-		LayerDBRoot:   layerDBRoot,
+func (fs *filesystem) ListImages() ([][]byte, error) {
+	var (
+		configs   [][]byte
+		err       error
+		fileInfos []os.FileInfo
+	)
+	fileInfos, err = ioutil.ReadDir(imageDBRoot)
+	if err != nil {
+		return nil, errors.Errorf("failed to open metadata directory %s, err: %v",
+			imageDBRoot, err)
 	}
+
+	for _, fileInfo := range fileInfos {
+		if fileInfo.IsDir() {
+			continue
+		}
+
+		if strings.Contains(fileInfo.Name(), common.YamlSuffix) {
+			config, err := ioutil.ReadFile(metadataDir(fileInfo.Name()))
+			if err != nil {
+				logger.Error("failed to read file %v, err: %v", fileInfo.Name(), err)
+			}
+			configs = append(configs, config)
+		}
+	}
+
+	return configs, nil
 }
 
-func NewDefaultLayerStorage() LayerStorage {
-	return NewLayerStorage(layerDataRoot, layerDBRoot)
+func (fs *filesystem) SetMetadata(id digest.Digest, key string, data []byte) error {
+	fs.Lock()
+	defer fs.Unlock()
+
+	baseDir := fs.LayerDBDir(id)
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(filepath.Join(baseDir, key), data, 0644)
+}
+
+func (fs *filesystem) GetMetadata(id digest.Digest, key string) ([]byte, error) {
+	fs.Lock()
+	defer fs.Unlock()
+
+	bytes, err := ioutil.ReadFile(filepath.Join(fs.LayerDBDir(id), key))
+	if err != nil {
+		return nil, errors.Errorf("failed to read metadata, err: %v", err)
+	}
+
+	return bytes, nil
+}
+
+func (fs *filesystem) DeleteMetadata(id digest.Digest, key string) error {
+	fs.Lock()
+	defer fs.Unlock()
+
+	return os.RemoveAll(filepath.Join(fs.LayerDBDir(id), key))
+}
+
+func (fs *filesystem) LayerDBDir(digest digest.Digest) string {
+	return filepath.Join(fs.layerDBRoot, digest.Algorithm().String(), digest.Hex())
+}
+
+func (fs *filesystem) LayerDataDir(digest digest.Digest) string {
+	return filepath.Join(fs.layerDataRoot, digest.Hex())
+}
+
+func (fs *filesystem) storeROLayer(layer Layer) error {
+	dig := digest.Digest(layer.ID())
+	dbDir := fs.LayerDBDir(dig)
+	err := pkgutils.WriteFile(filepath.Join(dbDir, "size"), []byte(fmt.Sprintf("%d", layer.Size())))
+	if err != nil {
+		return fmt.Errorf("failed to write size for %s, err: %s", layer.ID(), err)
+	}
+
+	err = fs.addDistributionMetadata(layer.ID(), layer.DistributionMetadata())
+	if err != nil {
+		return fmt.Errorf("failed to write distribution metadata for %s, err: %s", layer.ID(), err)
+	}
+
+	err = pkgutils.WriteFile(filepath.Join(dbDir, "id"), []byte(layer.ID()))
+	logger.Debug("writing id %s to %s", layer.ID(), filepath.Join(dbDir, "id"))
+	if err != nil {
+		return fmt.Errorf("failed to write id for %s, err: %s", layer.ID(), err)
+	}
+
+	return nil
+}
+
+func (fs *filesystem) loadLayerID(layerDBPath string) (LayerID, error) {
+	fs.RLock()
+	defer fs.RUnlock()
+
+	idBytes, err := ioutil.ReadFile(filepath.Join(layerDBPath, "id"))
+	if err != nil {
+		return "", err
+	}
+	dig, err := digest.Parse(string(idBytes))
+	if err != nil {
+		return "", err
+	}
+	return LayerID(dig), nil
+}
+
+func (fs *filesystem) loadLayerSize(layerDBPath string) (int64, error) {
+	fs.RLock()
+	defer fs.RUnlock()
+
+	sizeBytes, err := ioutil.ReadFile(filepath.Join(layerDBPath, "size"))
+	if err != nil {
+		return 0, err
+	}
+
+	size, err := strconv.ParseInt(string(sizeBytes), 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return size, nil
+}
+
+func (fs *filesystem) loadROLayer(layerDBPath string) (*ROLayer, error) {
+	layerID, err := fs.loadLayerID(layerDBPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get layer metadata %s, whose id file lost, err: %s", filepath.Base(layerDBPath), err)
+	}
+
+	layerSize, err := fs.loadLayerSize(layerDBPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read size of layer %s, err: %s", filepath.Base(layerDBPath), err)
+	}
+
+	metadataMap, err := fs.LoadDistributionMetadata(layerID)
+	if err != nil {
+		// we could tolerate the miss of DistributionMetadata.
+		// the consequence is that we push the layer repeatedly
+		logger.Warn("failed to get layer distribution digest, err: %s", filepath.Base(layerDBPath), err)
+	}
+
+	return NewROLayer(
+		layerID.ToDigest(),
+		layerSize,
+		metadataMap,
+	)
+}
+
+func (fs *filesystem) loadAllROLayers() ([]*ROLayer, error) {
+	layerDirs, err := traverseLayerDB(fs.layerDBRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	var layers []*ROLayer
+	for _, layerDBDir := range layerDirs {
+		rolayer, err := fs.loadROLayer(layerDBDir)
+		if err != nil {
+			logger.Warn(err)
+			continue
+		}
+		layers = append(layers, rolayer)
+	}
+	return layers, nil
 }

--- a/image/store/layer_store_test.go
+++ b/image/store/layer_store_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package store
 
 import (
@@ -55,18 +69,22 @@ func makeFakeLayer(layer mockROLayer) error {
 	return nil
 }
 
-func cleanTmpLayers(layer mockROLayer) {
+func cleanTmpLayers(layer mockROLayer) error {
 	_ = os.Remove(layer.tmpRelPath)
-	lsg := NewDefaultLayerStorage()
-	err := os.RemoveAll(lsg.LayerDataDir(layer.roLayer.id.ToDigest()))
+	backend, err := NewFSStoreBackend()
+	if err != nil {
+		return err
+	}
+	err = os.RemoveAll(backend.LayerDataDir(layer.roLayer.id.ToDigest()))
 	if err != nil {
 		logger.Warn(err)
 	}
 
-	err = os.RemoveAll(lsg.LayerDBDir(layer.roLayer.id.ToDigest()))
+	err = os.RemoveAll(backend.LayerDBDir(layer.roLayer.id.ToDigest()))
 	if err != nil {
 		logger.Warn(err)
 	}
+	return nil
 }
 
 func TestLayerStore_RegisterLayerForBuilder(t *testing.T) {
@@ -108,7 +126,10 @@ func TestLayerStore_RegisterLayerForBuilder(t *testing.T) {
 
 	defer func() {
 		for _, layer := range newLayers {
-			cleanTmpLayers(layer)
+			err := cleanTmpLayers(layer)
+			if err != nil {
+				logger.Error(err)
+			}
 		}
 	}()
 

--- a/image/store/utils.go
+++ b/image/store/utils.go
@@ -40,9 +40,9 @@ func getDirListInDir(dir string) ([]string, error) {
 	return dirs, nil
 }
 
-func (ls LayerStorage) traverseLayerDB() ([]string, error) {
+func traverseLayerDB(layerDBRoot string) ([]string, error) {
 	// TODO maybe there no need to traverse layerdb, just clarify how many sha supported in a list
-	shaDirs, err := getDirListInDir(ls.LayerDBRoot)
+	shaDirs, err := getDirListInDir(layerDBRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/sealer/cmd/build.go
+++ b/sealer/cmd/build.go
@@ -26,6 +26,7 @@ type BuildFlag struct {
 	ImageName    string
 	KubefileName string
 	BuildType    string
+	NoCache      bool
 }
 
 var buildConfig *BuildFlag
@@ -42,6 +43,7 @@ var buildCmd = &cobra.Command{
 		}
 		conf := &build.Config{
 			BuildType: buildConfig.BuildType,
+			NoCache:   buildConfig.NoCache,
 		}
 		builder, err := build.NewBuilder(conf)
 		if err != nil {
@@ -63,6 +65,7 @@ func init() {
 	buildCmd.Flags().StringVarP(&buildConfig.BuildType, "buildType", "b", "", "cluster image build type,default is cloud")
 	buildCmd.Flags().StringVarP(&buildConfig.KubefileName, "kubefile", "f", "Kubefile", "kubefile filepath")
 	buildCmd.Flags().StringVarP(&buildConfig.ImageName, "imageName", "t", "", "cluster image name")
+	buildCmd.Flags().BoolVar(&buildConfig.NoCache, "no-cache", false, "build without cache")
 	if err := buildCmd.MarkFlagRequired("imageName"); err != nil {
 		logger.Error("failed to init flag: %v", err)
 		os.Exit(1)

--- a/seautil/cmd/build.go
+++ b/seautil/cmd/build.go
@@ -30,6 +30,7 @@ type BuildFlag struct {
 	KubefileName string
 	Context      string
 	BuildType    string
+	NoCache      bool
 }
 
 var buildConfig *BuildFlag
@@ -42,6 +43,7 @@ var buildCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		conf := &build.Config{
 			BuildType: buildConfig.BuildType,
+			NoCache:   buildConfig.NoCache,
 		}
 		builder, err := build.NewBuilder(conf)
 		if err != nil {
@@ -64,4 +66,5 @@ func init() {
 	buildCmd.Flags().StringVarP(&buildConfig.ImageName, "imageName", "t", "", "cluster image name")
 	buildCmd.Flags().StringVarP(&buildConfig.Context, "context", "c", ".", "cluster image build context file path")
 	buildCmd.Flags().StringVarP(&buildConfig.BuildType, "buildType", "b", common.LocalBuild, "specific of type is local build or cloud build default is local")
+	buildCmd.Flags().BoolVar(&buildConfig.NoCache, "no-cache", false, "build without cache")
 }

--- a/test/sealer_run_test.go
+++ b/test/sealer_run_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package test
 
 import (

--- a/utils/archive/compress.go
+++ b/utils/archive/compress.go
@@ -40,9 +40,6 @@ type Options struct {
 }
 
 func validatePath(path string) error {
-	if !filepath.IsAbs(path) {
-		return fmt.Errorf("dir %s must be absolute path", path)
-	}
 	if _, err := os.Stat(path); err != nil {
 		return fmt.Errorf("dir %s does not exist, err: %s", path, err)
 	}

--- a/utils/archive/compress_test.go
+++ b/utils/archive/compress_test.go
@@ -16,7 +16,9 @@
 package archive
 
 import (
+	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -105,15 +107,20 @@ func makeDir(root string, d dirDef) error {
 }
 
 func TestTarWithoutRootDir(t *testing.T) {
+	digest, _, err := TarCanonicalDigest("/Users/eric/Workspace/src/sealer/empty")
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Println(digest)
 }
 
 func TestTarWithRootDir(t *testing.T) {
-	reader, err := TarWithRootDir("/Users/eric/Workspace/src/github.com/vbauerster/mpb", "/Users/eric/Workspace/src/github.com/vbauerster/empty")
+	reader, err := TarWithRootDir("./hash.go")
 	if err != nil {
 		t.Error(err)
 	}
 
-	tmp, err := os.CreateTemp("/tmp", "tar")
+	tmp, err := ioutil.TempFile("/tmp", "tar")
 	_, err = io.Copy(tmp, reader)
 	if err != nil {
 		t.Error(err)

--- a/utils/archive/hash.go
+++ b/utils/archive/hash.go
@@ -1,0 +1,44 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/opencontainers/go-digest"
+)
+
+const emptySHA256TarDigest = "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+
+func TarCanonicalDigest(path string) (digest.Digest, int64, error) {
+	tarReader, err := TarWithoutRootDir(path)
+	if err != nil {
+		return "", 0, fmt.Errorf("unable to tar on %s, err: %s", path, err)
+	}
+	defer tarReader.Close()
+
+	digester := digest.Canonical.Digester()
+	size, err := io.Copy(digester.Hash(), tarReader)
+	if err != nil {
+		return "", 0, err
+	}
+	layerDigest := digester.Digest()
+	if layerDigest == emptySHA256TarDigest {
+		return "", 0, nil
+	}
+
+	return layerDigest, size, nil
+}


### PR DESCRIPTION
this is finishing pr for [#323](https://github.com/alibaba/sealer/pull/323)

### New Feature
This feature aims to bring layer cache ability to sealer build. The cache ability mainly disposes problems like waste of disk space, and repeating image id. By the way, this feature will bring more time consumption on sealer build, due to the cache id calculation.

There are some new structures and files that plays role in this feature.
cache Layer
```
type Layer struct {
	CacheID string `json:"cache_id"`
	Type    string `json:"type"`
	Value   string `json:"value"`
}
```
this "Layer" looks familiar to v1Layer, only CacheID and ID are different. ID of v1Layer is digest(tar(layer-files)). CacheID of cacheLayer is */layerdb/layerID/cacheID, which is calculated from src in `COPY src tar`.  CacheID is used to validate the consistency between src files from different `COPY src tar`, to see if it possible to hit the cache.

```
ChainID
```
I leant the The concept of ChainID from docker, but it's not complex like it's in docker. The key concept for ChainID is an entire file system over multiples layers. Which is computed over cache Layers.
The algorithm is:
```
func (l *Layer) ChainID(parentID ChainID) (ChainID, error) {
	if parentID.String() == "" {
		return ChainID(digest.FromString(l.String())), nil
	}
	return ChainID(digest.FromString(parentID.String() + ":" + l.String())), nil
}
```

We will use ChainID to hit cache, same ChainID means same file system.