### PR TITLE
add calico ipip config

### DIFF
--- a/runtime/init.go
+++ b/runtime/init.go
@@ -114,6 +114,7 @@ func (d *Default) initRunner(cluster *v1.Cluster) error {
 	d.PodCIDR = cluster.Spec.Network.PodCIDR
 	d.SvcCIDR = cluster.Spec.Network.SvcCIDR
 	d.WithoutCNI = cluster.Spec.Network.WithoutCNI
+	d.IPIP = cluster.Spec.Network.IPIP
 	if d.MTU == "" {
 		if d.IPIP {
 			d.MTU = "1480"

--- a/types/api/v1/cluster_types.go
+++ b/types/api/v1/cluster_types.go
@@ -31,6 +31,7 @@ type Network struct {
 	PodCIDR    string `json:"podCIDR,omitempty"`
 	SvcCIDR    string `json:"svcCIDR,omitempty"`
 	WithoutCNI bool   `json:"withoutCNI,omitempty"`
+	IPIP       bool   `json:"ipip,omitempty"`
 }
 
 type Hosts struct {


### PR DESCRIPTION
```
apiVersion: zlink.aliyun.com/v1alpha1
kind: Cluster
metadata:
  name: my-cluster
spec:
  certSANS:
  - aliyun-inc.com
  - 10.0.0.2
  image: kubernetes:v1.19.9
  masters:
    count: "1"
    cpu: "4"
    dataDisks:
    - "100"
    memory: "4"
    systemDisk: "100"
  network:
    cniName: calico
    interface: eth0
    ipip: true
    podCIDR: 100.64.0.0/10
    svcCIDR: 10.96.0.0/22
  provider: ALI_CLOUD
```

ipip: true will open IPIP