### PR TITLE
fix clustername the problem of reference variable error

### DIFF
--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -154,7 +154,7 @@ func (c *FileSystem) UnMountRootfs(cluster *v1.Cluster) error {
 func mountRootfs(ipList []string, target string, cluster *v1.Cluster) error {
 	SSH := ssh.NewSSHByCluster(cluster)
 	config := runtime.GetRegistryConfig(
-		common.DefaultTheClusterRootfsDir(cluster.ClusterName),
+		common.DefaultTheClusterRootfsDir(cluster.Name),
 		cluster.Spec.Masters.IPList[0])
 	if err := ssh.WaitSSHReady(SSH, ipList...); err != nil {
 		return errors.Wrap(err, "check for node ssh service time out")


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->
You should use: cluster.name instead of cluster.clustername, which results in a registry replication error
### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
