### PR TITLE
fix the execution directory is incorrect

### DIFF
--- a/apply/run.go
+++ b/apply/run.go
@@ -75,9 +75,8 @@ func (c *ClusterArgs) SetClusterArgs() error {
 	var flag bool
 	c.cluster.Spec.Image = c.imageName
 	c.cluster.Spec.Provider = common.BAREMETAL
-	if c.interfaceName != "" {
-		c.cluster.Spec.Network.Interface = c.interfaceName
-	}
+	c.cluster.Spec.Network.Interface = c.interfaceName
+
 	if c.podCidr != "" {
 		if flag, err = IsCidrString(c.podCidr); !flag {
 			return err

--- a/guest/guest.go
+++ b/guest/guest.go
@@ -16,7 +16,6 @@ package guest
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/alibaba/sealer/common"
 	"github.com/alibaba/sealer/image/utils"
@@ -45,7 +44,7 @@ func (d *Default) Apply(cluster *v1.Cluster) error {
 	if len(masters) == 0 {
 		return fmt.Errorf("failed to found master")
 	}
-	clusterRootfs := filepath.Join(common.DefaultClusterRootfsDir, cluster.Name)
+	clusterRootfs := common.DefaultTheClusterRootfsDir(cluster.Name)
 	for i := range image.Spec.Layers {
 		if image.Spec.Layers[i].Type != common.CMDCOMMAND {
 			continue


### PR DESCRIPTION
1. use auto detect network interface name by master ip, when no network interface is set using the sealer run #385
2. fix the execution directory is incorrect
fix #387
### Does this pull request fix one issue?

