### PR TITLE
Fix incorrectly copying dir path during build

### DIFF
--- a/build/local_builder.go
+++ b/build/local_builder.go
@@ -299,7 +299,7 @@ func (l *LocalBuilder) execLayer(layer *v1.Layer, tempTarget string) error {
 		dest := ""
 		if utils.IsDir(src) {
 			// src is dir
-			dest = filepath.Join(tempTarget, strings.Fields(layer.Value)[1])
+			dest = filepath.Join(tempTarget, strings.Fields(layer.Value)[1], filepath.Base(src))
 		} else {
 			// src is file
 			dest = filepath.Join(tempTarget, strings.Fields(layer.Value)[1], strings.Fields(layer.Value)[0])
@@ -308,7 +308,9 @@ func (l *LocalBuilder) execLayer(layer *v1.Layer, tempTarget string) error {
 	}
 	if layer.Type == common.RUNCOMMAND || layer.Type == common.CMDCOMMAND {
 		cmd := fmt.Sprintf(common.CdAndExecCmd, tempTarget, layer.Value)
-		if _, err := command.NewSimpleCommand(cmd).Exec(); err != nil {
+		output, err := command.NewSimpleCommand(cmd).Exec()
+		logger.Info(output)
+		if err != nil {
 			return fmt.Errorf("failed to exec %s, err: %v", cmd, err)
 		}
 	}

--- a/utils/file.go
+++ b/utils/file.go
@@ -74,8 +74,8 @@ func MkTmpdir() (string, error) {
 	return tempDir, os.MkdirAll(tempDir, os.ModePerm)
 }
 
-func MkTmpFile() (*os.File, error) {
-	return ioutil.TempFile(common.DefaultTmpDir, ".FTmp-")
+func MkTmpFile(path string) (*os.File, error) {
+	return ioutil.TempFile(path, ".FTmp-")
 }
 
 func IsFileExist(filename string) bool {

--- a/utils/fswriters.go
+++ b/utils/fswriters.go
@@ -25,7 +25,7 @@ func (a *atomicFileWriter) close() (err error) {
 }
 
 func newAtomicFileWriter(path string, perm os.FileMode) (*atomicFileWriter, error) {
-	tmpFile, err := MkTmpFile()
+	tmpFile, err := MkTmpFile(path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix incorrectly copying dir path during build  fix #436 
Fixed invalid cross-device link error when executing AtomicWrite on different file partitioning systems.  #434 