### PR TITLE
refactor: remove unuse const RemoteRestartDocker

### DIFF
--- a/runtime/masters.go
+++ b/runtime/masters.go
@@ -41,7 +41,6 @@ const (
 )
 
 const (
-	RemoteRestartDocker     = "systemctl restart docker"
 	RemoteAddEtcHosts       = "echo %s >> /etc/hosts"
 	RemoteUpdateEtcHosts    = `sed "s/%s/%s/g" -i /etc/hosts`
 	RemoteCopyKubeConfig    = `rm -rf .kube/config && mkdir -p /root/.kube && cp /etc/kubernetes/admin.conf /root/.kube/config`


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

remove unuse const RemoteRestartDocker

### Does this pull request fix one issue?

https://github.com/alibaba/sealer/blob/main/runtime/masters.go#L44
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

