### PR TITLE
fix: support tar overlay files

### DIFF
--- a/utils/archive/compress.go
+++ b/utils/archive/compress.go
@@ -22,6 +22,10 @@ import (
 	"fmt"
 	"syscall"
 
+	"github.com/alibaba/sealer/utils"
+
+	"golang.org/x/sys/unix"
+
 	"io"
 
 	"os"
@@ -127,6 +131,72 @@ func compress(paths []string, options Options) (reader io.ReadCloser, err error)
 	return pr, nil
 }
 
+func writeWhiteout(header *tar.Header, fi os.FileInfo, path string) (*tar.Header, error) {
+	// overlay whiteout process
+	// this is a whiteout file
+	if fi.Mode()&os.ModeCharDevice != 0 && header.Devminor == 0 && header.Devmajor == 0 {
+		hName := header.Name
+		header.Name = filepath.Join(filepath.Dir(hName), WhiteoutPrefix+filepath.Base(hName))
+		header.Mode = 0600
+		header.Typeflag = tar.TypeReg
+		header.Size = 0
+	}
+
+	var woh *tar.Header
+	if fi.Mode()&os.ModeDir != 0 {
+		opaque, walkErr := utils.Lgetxattr(path, "trusted.overlay.opaque")
+		if walkErr != nil {
+			return nil, walkErr
+		}
+
+		if len(opaque) == 1 && opaque[0] == 'y' {
+			if header.PAXRecords != nil {
+				delete(header.PAXRecords, "trusted.overlay.opaque")
+			}
+
+			woh = &tar.Header{
+				Typeflag:   tar.TypeReg,
+				Mode:       header.Mode & int64(os.ModePerm),
+				Name:       filepath.Join(header.Name, WhiteoutOpaqueDir),
+				Size:       0,
+				Uid:        header.Uid,
+				Uname:      header.Uname,
+				Gid:        header.Gid,
+				Gname:      header.Gname,
+				AccessTime: header.AccessTime,
+				ChangeTime: header.ChangeTime,
+			}
+		}
+	}
+	return woh, nil
+}
+
+func readWhiteout(hdr *tar.Header, path string) (bool, error) {
+	var (
+		base = filepath.Base(path)
+		dir  = filepath.Dir(path)
+		err  error
+	)
+
+	switch {
+	case base == WhiteoutOpaqueDir:
+		err = unix.Setxattr(dir, "trusted.overlay.opaque", []byte{'y'}, 0)
+		return false, err
+	case strings.HasPrefix(base, WhiteoutPrefix):
+		oBase := base[len(WhiteoutPrefix):]
+		oPath := filepath.Join(dir, oBase)
+
+		// make a whiteout file
+		err = unix.Mknod(oPath, unix.S_IFCHR, 0)
+		if err != nil {
+			return false, err
+		}
+		return false, os.Chown(oPath, hdr.Uid, hdr.Gid)
+	}
+
+	return true, nil
+}
+
 func writeToTarWriter(path string, tarWriter *tar.Writer, bufWriter *bufio.Writer, options Options) error {
 	var newFolder string
 	if options.KeepRootDir {
@@ -147,6 +217,7 @@ func writeToTarWriter(path string, tarWriter *tar.Writer, bufWriter *bufio.Write
 		if walkErr != nil {
 			return walkErr
 		}
+		// root dir
 		if file != dir {
 			absPath := filepath.ToSlash(file)
 			header.Name = filepath.Join(newFolder, strings.TrimPrefix(absPath, srcPrefix))
@@ -158,23 +229,44 @@ func writeToTarWriter(path string, tarWriter *tar.Writer, bufWriter *bufio.Write
 			// for supporting tar single file
 			header.Name = filepath.Join(newFolder, filepath.Base(dir))
 		}
+		// if current file is whiteout, the header has been changed,
+		// and we write a reg header into tar stream, but will not read its content
+		// cause doing so will lead to error. (its size is 0)
 
+		// if current target is dir, we will check if it is an opaque.
+		// and set add Suffix WhiteoutOpaqueDir for opaque.
+		// but we still need to write its original header into tar stream,
+		// because we need to create dir on this original header.
+		woh, walkErr := writeWhiteout(header, fi, file)
+		if walkErr != nil {
+			return fmt.Errorf("failed to write white out, path: %s, err: %v", file, walkErr)
+		}
 		walkErr = tarWriter.WriteHeader(header)
 		if walkErr != nil {
-			return walkErr
+			return fmt.Errorf("failed to write original header, path: %s, err: %v", file, walkErr)
 		}
-		// if not a dir, write file content
-		if !fi.IsDir() {
-			data, walkErr := os.Open(file)
+		// this is a opaque, write the opaque header, in order to set header.PAXRecords with trusted.overlay.opaque:y
+		// when decompress the tar stream.
+		if woh != nil {
+			walkErr = tarWriter.WriteHeader(woh)
+			if walkErr != nil {
+				return fmt.Errorf("failed to write opaque header, path: %s, err: %v", file, walkErr)
+			}
+		}
+		// if not a dir && size > 0, write file content
+		// the whiteout size is 0
+		if header.Typeflag == tar.TypeReg && header.Size > 0 {
+			var fHandler *os.File
+			fHandler, walkErr = os.Open(file)
 			if walkErr != nil {
 				return walkErr
 			}
-			defer data.Close()
+			defer fHandler.Close()
 
 			bufWriter.Reset(tarWriter)
 			defer bufWriter.Reset(nil)
 
-			_, walkErr = io.Copy(bufWriter, data)
+			_, walkErr = io.Copy(bufWriter, fHandler)
 			if walkErr != nil {
 				return walkErr
 			}
@@ -188,6 +280,24 @@ func writeToTarWriter(path string, tarWriter *tar.Writer, bufWriter *bufio.Write
 	})
 
 	return err
+}
+
+func removePreviousFiles(path string) error {
+	base := filepath.Base(path)
+	dir := filepath.Dir(path)
+	existPath := path
+	if strings.HasPrefix(base, WhiteoutPrefix) {
+		existPath = filepath.Join(dir, strings.TrimPrefix(base, WhiteoutPrefix))
+	}
+
+	_, err := os.Stat(existPath)
+	if err == nil {
+		err = os.RemoveAll(existPath)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Decompress this will not change the metadata of original files
@@ -230,7 +340,21 @@ func Decompress(src io.Reader, dst string, options Options) (int64, error) {
 			return 0, fmt.Errorf("tar contained invalid name error %q", header.Name)
 		}
 
+		// overwrite previous files
 		target := filepath.Join(dst, header.Name)
+		err = removePreviousFiles(target)
+		if err != nil {
+			return 0, err
+		}
+
+		goon, err := readWhiteout(header, target)
+		if err != nil {
+			return 0, err
+		}
+		// it is a opaque / whiteout, don't write its file content.
+		if !goon {
+			continue
+		}
 
 		switch header.Typeflag {
 		case tar.TypeDir:

--- a/utils/archive/compress_test.go
+++ b/utils/archive/compress_test.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 const basePath = "/tmp"
@@ -125,4 +127,16 @@ func TestTarWithRootDir(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+}
+
+func TestName(t *testing.T) {
+	//err := os.Mkdir("abc", 0755)
+	//if err != nil {
+	//	t.Error(err)
+	//}
+	err := unix.Setxattr("abc", "trusted.overlay.opaque", []byte{'y'}, 0)
+	if err != nil {
+		t.Error(err)
+	}
+	//fmt.Println(fm.String())
 }

--- a/utils/archive/const.go
+++ b/utils/archive/const.go
@@ -1,0 +1,36 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file content is extracted from "github.com/docker/docker/pkg/system"
+
+package archive
+
+const (
+	// WhiteoutPrefix means this file is a whiteout(deleted at the merge layer)
+	WhiteoutPrefix = ".wh."
+
+	// WhiteoutMetaPrefix prefix means whiteout has a special meaning and is not
+	// for removing an actual file. Normally these files are excluded from exported
+	// archives.
+	WhiteoutMetaPrefix = WhiteoutPrefix + WhiteoutPrefix
+
+	// WhiteoutLinkDir is a directory AUFS uses for storing hardlink links to other
+	// layers. Normally these should not go into exported archives and all changed
+	// hardlinks should be copied to the top layer.
+	WhiteoutLinkDir = WhiteoutMetaPrefix + "plnk"
+
+	// WhiteoutOpaqueDir file means directory has been made opaque - meaning
+	// readdir calls to this directory do not follow to lower layers.
+	WhiteoutOpaqueDir = WhiteoutMetaPrefix + ".opq"
+)

--- a/utils/system.go
+++ b/utils/system.go
@@ -1,0 +1,54 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is extracted from "github.com/docker/docker/pkg/system"
+
+package utils
+
+import "golang.org/x/sys/unix"
+
+// Lgetxattr retrieves the value of the extended attribute identified by attr
+// and associated with the given path in the file system.
+// It will returns a nil slice and nil error if the xattr is not set.
+func Lgetxattr(path string, attr string) ([]byte, error) {
+	// Start with a 128 length byte array
+	dest := make([]byte, 128)
+	sz, errno := unix.Lgetxattr(path, attr, dest)
+
+	switch {
+	case errno == unix.ENODATA:
+		return nil, nil
+	case errno == unix.ERANGE:
+		// 128 byte array might just not be good enough. A dummy buffer is used
+		// to get the real size of the xattrs on disk
+		sz, errno = unix.Lgetxattr(path, attr, []byte{})
+		if errno != nil {
+			return nil, errno
+		}
+		dest = make([]byte, sz)
+		sz, errno = unix.Lgetxattr(path, attr, dest)
+		if errno != nil {
+			return nil, errno
+		}
+	case errno != nil:
+		return nil, errno
+	}
+	return dest[:sz], nil
+}
+
+// Lsetxattr sets the value of the extended attribute identified by attr
+// and associated with the given path in the file system.
+func Lsetxattr(path string, attr string, data []byte, flags int) error {
+	return unix.Lsetxattr(path, attr, data, flags)
+}


### PR DESCRIPTION
we need to capable of serialize overlays files and opaque directory into tar stream, and deserialize them from tar stream.

such kind of processing tar stream is used at overlay upperdir majorly. 
* at tar stage, if we found that the current object is a whiteout(fi.Mode()&os.ModeCharDevice != 0 && header.Devminor == 0 && header.Devmajor == 0), we will add ".wh." as prefix to its header name, and set its size as 0, to make sure we won't read its content, which avoid whiteout read fault.
* at tar stage, if we found that the current object if opaque dir, dir with "trusted.overlay.opaque:y" attribute. we will set its header name as filepath.Join(header.Name, WhiteoutOpaqueDir)

when we untar them, will do corresponding jobs to recover original upper context.