### PR TITLE
add apply precheck

### DIFF
--- a/check/checker/apply_checker.go
+++ b/check/checker/apply_checker.go
@@ -1,0 +1,78 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/alibaba/sealer/utils/mount"
+
+	"github.com/alibaba/sealer/common"
+
+	v1 "github.com/alibaba/sealer/types/api/v1"
+	"github.com/alibaba/sealer/utils"
+)
+
+type ApplyChecker struct {
+	Desired *v1.Cluster
+	Current *v1.Cluster
+}
+
+func (a ApplyChecker) Check() error {
+	desiredMasters := a.Desired.Spec.Masters
+	desiredNodes := a.Desired.Spec.Nodes
+	a.Desired.Spec.Masters.IPList = utils.RemoveDuplicate(desiredMasters.IPList)
+	a.Desired.Spec.Nodes.IPList = utils.RemoveDuplicate(desiredNodes.IPList)
+	//should not be master and node at the same time
+	if utils.HasSameHosts(desiredMasters, desiredNodes) {
+		return fmt.Errorf("should not be master and node at the same time")
+	}
+	if a.Current != nil {
+		if utils.HasSameHosts(a.Current.Spec.Masters, desiredNodes) ||
+			utils.HasSameHosts(a.Current.Spec.Nodes, desiredMasters) {
+			return fmt.Errorf("masters nodes do not convert to each other")
+		}
+		MastersToJoin, MastersToDelete := utils.GetDiffHosts(a.Current.Spec.Masters, a.Desired.Spec.Masters)
+		NodesToJoin, NodesToDelete := utils.GetDiffHosts(a.Current.Spec.Nodes, a.Desired.Spec.Nodes)
+		//master node should not scale up or down at the same time
+		if (len(MastersToDelete) > 0) == (len(NodesToJoin) > 0) ||
+			(len(MastersToJoin) > 0) == (len(NodesToDelete) > 0) {
+			return fmt.Errorf("should not scale up or down at the same time")
+		}
+	} else {
+		//clean cluster base dir
+		baseDir := common.DefaultClusterBaseDir(a.Desired.Name)
+		if utils.IsFileExist(baseDir) {
+			err := mount.RetryUmountCleanDir(filepath.Join(baseDir, "mount"))
+			if err != nil {
+				return err
+			}
+			err = os.RemoveAll(baseDir)
+			if err != nil {
+				return fmt.Errorf("failed to clean cluster base dir %s: %v, please delete the directory and retry", baseDir, err)
+			}
+		}
+	}
+	return nil
+}
+
+func NewApplyChecker(current, desired *v1.Cluster) Checker {
+	return &ApplyChecker{
+		Current: current,
+		Desired: desired,
+	}
+}

--- a/check/checker/host_checker.go
+++ b/check/checker/host_checker.go
@@ -1,0 +1,53 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checker
+
+import (
+	"fmt"
+
+	"github.com/alibaba/sealer/utils"
+	"github.com/alibaba/sealer/utils/ssh"
+)
+
+type HostChecker struct {
+	SSH    ssh.Interface
+	ipList []string
+}
+
+func (a HostChecker) Check() error {
+	var hostnameList []string
+	for _, ip := range a.ipList {
+		err := ssh.WaitSSHReady(a.SSH, ip)
+		if err != nil {
+			return err
+		}
+		//hostname check
+		hostname, err := a.SSH.CmdToString(ip, "hostname", "")
+		if err != nil {
+			return fmt.Errorf("failed to get host %s hostname, %v", ip, err)
+		}
+		hostnameList = append(hostnameList, hostname)
+		//TODO CPU, Memory or more Check
+	}
+
+	if len(hostnameList) != len(utils.RemoveDuplicate(hostnameList)) {
+		return fmt.Errorf("hostname cannot be repeated, please set diffent hostname")
+	}
+	return nil
+}
+
+func NewHostChecker(s ssh.Interface, ipList []string) Checker {
+	return &HostChecker{s, ipList}
+}

--- a/check/service/pre_apply_check.go
+++ b/check/service/pre_apply_check.go
@@ -1,0 +1,53 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"github.com/alibaba/sealer/check/checker"
+	"github.com/alibaba/sealer/logger"
+	v1 "github.com/alibaba/sealer/types/api/v1"
+	"github.com/alibaba/sealer/utils/ssh"
+)
+
+type PreApplyCheckerService struct {
+	currentCluster, desiredCluster *v1.Cluster
+}
+
+func (d *PreApplyCheckerService) Run() error {
+	checkerList, err := d.init()
+	if err != nil {
+		logger.Error(err)
+		return err
+	}
+	for _, Checker := range checkerList {
+		err = Checker.Check()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *PreApplyCheckerService) init() ([]checker.Checker, error) {
+	var checkerList []checker.Checker
+	SSH := ssh.NewSSHByCluster(d.desiredCluster)
+	hostCheckIPList := append(d.desiredCluster.Spec.Masters.IPList, d.desiredCluster.Spec.Nodes.IPList...)
+	checkerList = append(checkerList, checker.NewApplyChecker(d.currentCluster, d.desiredCluster), checker.NewHostChecker(SSH, hostCheckIPList))
+	return checkerList, nil
+}
+
+func NewPreApplyCheckerService(currentCluster, desiredCluster *v1.Cluster) CheckerService {
+	return &PreApplyCheckerService{currentCluster, desiredCluster}
+}

--- a/utils/hosts.go
+++ b/utils/hosts.go
@@ -48,3 +48,20 @@ func IsInContainer() bool {
 	}
 	return strings.Contains(string(data), "container=docker")
 }
+
+func HasSameHosts(hostsOld, hostsNew v1.Hosts) bool {
+	return HasSameIPList(hostsOld.IPList, hostsNew.IPList)
+}
+
+func HasSameIPList(IPListOld, IPListNew []string) bool {
+	diffMap := make(map[string]bool)
+	for _, v := range IPListOld {
+		diffMap[v] = true
+	}
+	for _, v := range IPListNew {
+		if diffMap[v] {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
add apply precheck
add hostname check

fix #503   The last kubelet.conf was used because the environment was not cleaned up after the last execution.

https://github.com/alibaba/sealer/blob/6549495ad4ad4272cce80f341a0b5e0a2d245a4f/cert/kubeconfig.go#L277