### PR TITLE
feature: Use shell to check node cgroup driver before kubeadm init and join

### DIFF
--- a/runtime/init.go
+++ b/runtime/init.go
@@ -118,6 +118,8 @@ func (d *Default) ConfigKubeadmOnMaster0() error {
 	var err error
 	var tpl []byte
 	var fileData []byte
+	// on master init .we need to get master0 cgroupdriver.
+	d.CriCGroupDriver = d.getCgroupDriverFromShell(d.Masters[0])
 	if d.KubeadmFilePath == "" {
 		tpl, err = d.defaultTemplate()
 		if err != nil {

--- a/runtime/kubeadm.go
+++ b/runtime/kubeadm.go
@@ -82,7 +82,7 @@ func (d *Default) setKubeadmAPIByVersion() {
 		d.KubeadmAPI = KubeadmV1beta2
 		d.CriSocket = DefaultContainerdCRISocket
 	default:
-		// 兼容一下 1.14 以下版本.
+		// Compatible with versions 1.14 and 1.13. but do not recommended.
 		d.KubeadmAPI = KubeadmV1beta1
 		d.CriSocket = DefaultDockerCRISocket
 	}

--- a/runtime/kubeadm.go
+++ b/runtime/kubeadm.go
@@ -78,7 +78,7 @@ func (d *Default) setKubeadmAPIByVersion() {
 		d.CriSocket = DefaultDockerCRISocket
 		d.KubeadmAPI = KubeadmV1beta2
 	// kubernetes gt 1.20, use Containerd instead of docker
-	case VersionCompare(d.Metadata.Version, V1200) :
+	case VersionCompare(d.Metadata.Version, V1200):
 		d.KubeadmAPI = KubeadmV1beta2
 		d.CriSocket = DefaultContainerdCRISocket
 	default:

--- a/runtime/masters.go
+++ b/runtime/masters.go
@@ -38,6 +38,7 @@ const (
 	V1992 = "v1.19.2"
 	V1150 = "v1.15.0"
 	V1200 = "v1.20.0"
+	V1230 = "v1.23.0"
 )
 
 const (
@@ -81,6 +82,14 @@ const (
 	// CriSocket
 	DefaultDockerCRISocket     = "/var/run/dockershim.sock"
 	DefaultContainerdCRISocket = "/run/containerd/containerd.sock"
+	DefaultSystemdCgroupDriver = "systemd"
+	DefaultCgroupDriver        = "cgroupfs"
+
+	// kubeadm api version
+	KubeadmV1beta1 = "kubeadm.k8s.io/v1beta1"
+	KubeadmV1beta2 = "kubeadm.k8s.io/v1beta2"
+	KubeadmV1beta3 = "kubeadm.k8s.io/v1beta3"
+
 )
 
 const (
@@ -97,6 +106,8 @@ const (
 	CertSANS             = "CertSANS"
 	EtcdServers          = "EtcdServers"
 	CriSocket            = "CriSocket"
+	CriCGroupDriver      = "CriCGroupDriver"
+	KubeadmAPI           = "KubeadmAPI"
 	TokenDiscoveryCAHash = "TokenDiscoveryCAHash"
 	SeaHub               = "sea.hub"
 )
@@ -176,11 +187,12 @@ func (d *Default) SendJoinMasterKubeConfigs(masters []string, files ...string) {
 
 func joinKubeadmConfig() string {
 	var sb strings.Builder
-	sb.Write([]byte(JoinCPTemplateTextV1beta2))
+	sb.Write([]byte(JoinCPTemplateText))
 	return sb.String()
 }
 
 func (d *Default) JoinTemplateFromTemplateContent(templateContent, ip string) []byte {
+	d.setKubeadmAPIByVersion()
 	tmpl, err := template.New("text").Parse(templateContent)
 	if err != nil {
 		logger.Error("template join config failed %v", err)
@@ -192,11 +204,11 @@ func (d *Default) JoinTemplateFromTemplateContent(templateContent, ip string) []
 	envMap[TokenDiscovery] = d.JoinToken
 	envMap[TokenDiscoveryCAHash] = d.TokenCaCertHash
 	envMap[VIP] = d.VIP
-	if VersionCompare(d.Metadata.Version, V1200) {
-		envMap[CriSocket] = DefaultContainerdCRISocket
-	} else {
-		envMap[CriSocket] = DefaultDockerCRISocket
-	}
+	envMap[KubeadmAPI] = d.KubeadmAPI
+	envMap[CriSocket] = d.CriSocket
+	// we need to Dynamic get cgroup driver on ervery join nodes.
+	envMap[CriCGroupDriver] = d.CriCGroupDriver
+
 	var buffer bytes.Buffer
 	err = tmpl.Execute(&buffer, envMap)
 	if err != nil {
@@ -210,6 +222,25 @@ func (d *Default) JoinTemplate(ip string) []byte {
 	return d.JoinTemplateFromTemplateContent(joinKubeadmConfig(), ip)
 }
 
+// getCgroupDriverFromShell is get nodes container runtime cgroup by shell.
+func (d *Default) getCgroupDriverFromShell(node string) string {
+	var cmd string
+	if VersionCompare(d.Metadata.Version, V1200) {
+		cmd = ContainerdShell
+	} else {
+		cmd = DockerShell
+	}
+	driver, err := d.SSH.CmdToString(node, cmd, " ")
+	if err != nil {
+		// by default if we get wrong output we set it default systemd?
+		driver = DefaultSystemdCgroupDriver
+		logger.Error("get nodes [%s] cgroup driver err: %v", node, err)
+	}
+	driver = strings.TrimSpace(driver)
+	logger.Debug("get nodes [%s] cgroup driver is [%s]", node, driver)
+	return driver
+}
+
 // sendJoinCPConfig send join CP nodes configuration
 func (d *Default) sendJoinCPConfig(joinMaster []string) {
 	var wg sync.WaitGroup
@@ -217,6 +248,8 @@ func (d *Default) sendJoinCPConfig(joinMaster []string) {
 		wg.Add(1)
 		go func(master string) {
 			defer wg.Done()
+			// set d.CriCGroupDriver on every nodes.
+			d.CriCGroupDriver = d.getCgroupDriverFromShell(master)
 			templateData := string(d.JoinTemplate(utils.GetHostIP(master)))
 			cmd := fmt.Sprintf(RemoteJoinMasterConfig, templateData, d.Rootfs)
 			err := d.SSH.CmdAsync(master, cmd)

--- a/runtime/masters.go
+++ b/runtime/masters.go
@@ -89,7 +89,6 @@ const (
 	KubeadmV1beta1 = "kubeadm.k8s.io/v1beta1"
 	KubeadmV1beta2 = "kubeadm.k8s.io/v1beta2"
 	KubeadmV1beta3 = "kubeadm.k8s.io/v1beta3"
-
 )
 
 const (

--- a/runtime/nodes.go
+++ b/runtime/nodes.go
@@ -58,7 +58,7 @@ func (d *Default) joinNodes(nodes []string) error {
 		masters += fmt.Sprintf(" --rs %s:6443", utils.GetHostIP(master))
 	}
 	ipvsCmd := fmt.Sprintf(RemoteAddIPVS, d.VIP, masters)
-	templateData := string(d.JoinTemplate(""))
+
 	cmdAddRegistryHosts := fmt.Sprintf(RemoteAddEtcHosts, getRegistryHost(d.Rootfs, d.Masters[0]))
 	for _, node := range nodes {
 		wg.Add(1)
@@ -72,7 +72,9 @@ func (d *Default) joinNodes(nodes []string) error {
 					d.CmdToString(node, addRouteCmd, "")
 				}
 			*/
-			// send join node config
+			// send join node config, get cgroup driver on every join nodes
+			d.CriCGroupDriver = d.getCgroupDriverFromShell(node)
+			templateData := string(d.JoinTemplate(""))
 			cmdJoinConfig := fmt.Sprintf(RemoteJoinConfig, templateData, d.Rootfs)
 			cmdHosts := fmt.Sprintf(RemoteAddIPVSEtcHosts, d.VIP, d.APIServer)
 			cmd := d.Command(d.Metadata.Version, JoinNode)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -73,6 +73,9 @@ type Default struct {
 	Rootfs            string
 	BasePath          string
 	imageStore        store.ImageStore
+	CriSocket         string
+	CriCGroupDriver   string
+	KubeadmAPI        string
 }
 
 func NewDefaultRuntime(cluster *v1.Cluster) Interface {

--- a/runtime/template.go
+++ b/runtime/template.go
@@ -24,7 +24,6 @@ const (
 		kubeletConfigDefault)
 
 	bootstrapTokenDefault = `apiVersion: {{.KubeadmAPI}}
-{{- end}}
 caCertPath: /etc/kubernetes/pki/ca.crt
 discovery:
   bootstrapToken:

--- a/runtime/template.go
+++ b/runtime/template.go
@@ -14,77 +14,17 @@
 
 package runtime
 
-const InitTemplateTextV1beta1 = `
-apiVersion: kubeadm.k8s.io/v1beta1
-kind: ClusterConfiguration
-kubernetesVersion: {{.Version}}
-controlPlaneEndpoint: "{{.ApiServer}}:6443"
-imageRepository: {{.Repo}}
-networking:
-  # dnsDomain: cluster.local
-  podSubnet: {{.PodCIDR}}
-  serviceSubnet: {{.SvcCIDR}}
-apiServer:
-  certSANs:
-  {{range .CertSANS -}}
-  - {{.}}
-  {{end -}}
-  extraArgs:
-    etcd-servers: {{.EtcdServers}}
-    feature-gates: TTLAfterFinished=true,EphemeralContainers=true
-    audit-policy-file: "/etc/kubernetes/audit-policy.yml"
-    audit-log-path: "/var/log/kubernetes/audit.log"
-    audit-log-format: json
-    audit-log-maxbackup: '"10"'
-    audit-log-maxsize: '"100"'
-    audit-log-maxage: '"7"'
-    enable-aggregator-routing: '"true"'
-  extraVolumes:
-  - name: "audit"
-    hostPath: "/etc/kubernetes"
-    mountPath: "/etc/kubernetes"
-    pathType: DirectoryOrCreate
-  - name: "audit-log"
-    hostPath: "/var/log/kubernetes"
-    mountPath: "/var/log/kubernetes"
-    pathType: DirectoryOrCreate
-  - name: localtime
-    hostPath: /etc/localtime
-    mountPath: /etc/localtime
-    readOnly: true
-    pathType: File
-controllerManager:
-  extraArgs:
-    feature-gates: TTLAfterFinished=true,EphemeralContainers=true
-    experimental-cluster-signing-duration: 876000h
-  extraVolumes:
-  - hostPath: /etc/localtime
-    mountPath: /etc/localtime
-    name: localtime
-    readOnly: true
-    pathType: File
-scheduler:
-  extraArgs:
-    feature-gates: TTLAfterFinished=true,EphemeralContainers=true
-  extraVolumes:
-  - hostPath: /etc/localtime
-    mountPath: /etc/localtime
-    name: localtime
-    readOnly: true
-    pathType: File
-etcd:
-  local:
-    extraArgs:
-      listen-metrics-urls: http://0.0.0.0:2381
----
-apiVersion: kubeproxy.config.k8s.io/v1alpha1
-kind: KubeProxyConfiguration
-mode: "ipvs"
-ipvs:
-  excludeCIDRs:
-  - "{{.VIP}}/32"`
+const (
+	InitTemplateText = string(InitConfigurationDefault +
+		ClusterConfigurationDefault +
+		kubeproxyConfigDefault +
+		kubeletConfigDefault)
+	JoinCPTemplateText = string(bootstrapTokenDefault +
+		JoinConfigurationDefault +
+		kubeletConfigDefault)
 
-const JoinCPTemplateTextV1beta2 = string(`apiVersion: kubeadm.k8s.io/v1beta2
+	bootstrapTokenDefault = `apiVersion: {{.KubeadmAPI}}
+{{- end}}
 caCertPath: /etc/kubernetes/pki/ca.crt
 discovery:
   bootstrapToken:
@@ -97,6 +37,17 @@ discovery:
     caCertHashes:
     - {{.TokenDiscoveryCAHash}}
   timeout: 5m0s
+`
+	InitConfigurationDefault = `apiVersion: {{.KubeadmAPI}}
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: {{.Master0}}
+  bindPort: 6443
+nodeRegistration:
+  criSocket: {{.CriSocket}}
+`
+
+	JoinConfigurationDefault = `
 kind: JoinConfiguration
 {{- if .Master }}
 controlPlane:
@@ -105,10 +56,11 @@ controlPlane:
     bindPort: 6443
 {{- end}}
 nodeRegistration:
-  criSocket: {{.CriSocket}}`)
+  criSocket: {{.CriSocket}}
+`
 
-const InitTemplateTextV1bate2 = string(`
-apiVersion: kubeadm.k8s.io/v1beta2
+	ClusterConfigurationDefault = `---
+apiVersion: {{.KubeadmAPI}}
 kind: ClusterConfiguration
 kubernetesVersion: {{.Version}}
 controlPlaneEndpoint: "{{.ApiServer}}:6443"
@@ -169,10 +121,94 @@ etcd:
   local:
     extraArgs:
       listen-metrics-urls: http://0.0.0.0:2381
+`
+	kubeproxyConfigDefault = `
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 mode: "ipvs"
 ipvs:
   excludeCIDRs:
-  - "{{.VIP}}/32"`)
+  - "{{.VIP}}/32"
+`
+
+	kubeletConfigDefault = `
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+authentication:
+  anonymous:
+    enabled: false
+  webhook:
+    cacheTTL: 2m0s
+    enabled: true
+  x509:
+    clientCAFile: /etc/kubernetes/pki/ca.crt
+authorization:
+  mode: Webhook
+  webhook:
+    cacheAuthorizedTTL: 5m0s
+    cacheUnauthorizedTTL: 30s
+cgroupDriver: {{ .CgroupDriver}}
+cgroupsPerQOS: true
+clusterDomain: cluster.local
+configMapAndSecretChangeDetectionStrategy: Watch
+containerLogMaxFiles: 5
+containerLogMaxSize: 10Mi
+contentType: application/vnd.kubernetes.protobuf
+cpuCFSQuota: true
+cpuCFSQuotaPeriod: 100ms
+cpuManagerPolicy: none
+cpuManagerReconcilePeriod: 10s
+enableControllerAttachDetach: true
+enableDebuggingHandlers: true
+enforceNodeAllocatable:
+- pods
+eventBurst: 10
+eventRecordQPS: 5
+evictionHard:
+  imagefs.available: 15%
+  memory.available: 100Mi
+  nodefs.available: 10%
+  nodefs.inodesFree: 5%
+evictionPressureTransitionPeriod: 5m0s
+failSwapOn: true
+fileCheckFrequency: 20s
+hairpinMode: promiscuous-bridge
+healthzBindAddress: 127.0.0.1
+healthzPort: 10248
+httpCheckFrequency: 20s
+imageGCHighThresholdPercent: 85
+imageGCLowThresholdPercent: 80
+imageMinimumGCAge: 2m0s
+iptablesDropBit: 15
+iptablesMasqueradeBit: 14
+kubeAPIBurst: 10
+kubeAPIQPS: 5
+makeIPTablesUtilChains: true
+maxOpenFiles: 1000000
+maxPods: 110
+nodeLeaseDurationSeconds: 40
+nodeStatusReportFrequency: 10s
+nodeStatusUpdateFrequency: 10s
+oomScoreAdj: -999
+podPidsLimit: -1
+port: 10250
+registryBurst: 10
+registryPullQPS: 5
+rotateCertificates: true
+runtimeRequestTimeout: 2m0s
+serializeImagePulls: true
+staticPodPath: /etc/kubernetes/manifests
+streamingConnectionIdleTimeout: 4h0m0s
+syncFrequency: 1m0s
+volumeStatsAggPeriod: 1m0s`
+	ContainerdShell = `if grep "SystemdCgroup = true"  /etc/containerd/config.toml &> /dev/null; then  
+driver=systemd
+else
+driver=cgroupfs
+fi
+echo ${driver}`
+	DockerShell = `driver=$(docker info -f "{{.CgroupDriver}}")
+	echo "${driver}"`
+)

--- a/runtime/template.go
+++ b/runtime/template.go
@@ -46,8 +46,7 @@ nodeRegistration:
   criSocket: {{.CriSocket}}
 `
 
-	JoinConfigurationDefault = `
-kind: JoinConfiguration
+	JoinConfigurationDefault = `kind: JoinConfiguration
 {{- if .Master }}
 controlPlane:
   localAPIEndpoint:


### PR DESCRIPTION
Signed-off-by: oldthreefeng <louisehong4168@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

if we dont check node cgroupdriver and don't specific cgroup driver.  kubeadm will set it by default value.


### Does this pull request fix one issue?

Fixes #489 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

use shell to get .

### Describe how to verify it


### Special notes for reviews
