### PR TITLE
optimize: add unparam golangci-lint rule to remove unused parameters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,7 @@ linters:
     - structcheck
     - unused
     - varcheck
+    - unparam
 
 issues:
   exclude-rules:

--- a/apply/default_applier.go
+++ b/apply/default_applier.go
@@ -194,7 +194,7 @@ func (c *DefaultApplier) Apply() (err error) {
 		}
 	}
 
-	todoList, _ := c.diff()
+	todoList := c.diff()
 	for _, action := range todoList {
 		logger.Debug("sealer apply process %s", action)
 		err := ActionFuncMap[action](c)
@@ -212,7 +212,7 @@ func (c *DefaultApplier) Delete() (err error) {
 	return c.Apply()
 }
 
-func (c *DefaultApplier) diff() (todoList []ActionName, err error) {
+func (c *DefaultApplier) diff() (todoList []ActionName) {
 	if c.ClusterDesired.DeletionTimestamp != nil {
 		c.MastersToDelete = c.ClusterDesired.Spec.Masters.IPList
 		c.NodesToDelete = c.ClusterDesired.Spec.Nodes.IPList
@@ -220,7 +220,7 @@ func (c *DefaultApplier) diff() (todoList []ActionName, err error) {
 		todoList = append(todoList, UnMountRootfs)
 		todoList = append(todoList, UnMountImage)
 		todoList = append(todoList, CleanFS)
-		return todoList, nil
+		return todoList
 	}
 
 	if c.ClusterCurrent == nil {
@@ -239,7 +239,7 @@ func (c *DefaultApplier) diff() (todoList []ActionName, err error) {
 		todoList = append(todoList, Guest)
 		todoList = append(todoList, UnMountImage)
 		todoList = append(todoList, PluginPhasePostInstallRun)
-		return todoList, nil
+		return todoList
 	}
 
 	todoList = append(todoList, PullIfNotExist)
@@ -259,7 +259,7 @@ func (c *DefaultApplier) diff() (todoList []ActionName, err error) {
 	}
 	todoList = append(todoList, Guest)
 	todoList = append(todoList, UnMountImage)
-	return todoList, nil
+	return todoList
 }
 
 func NewDefaultApplier(cluster *v1.Cluster) (Interface, error) {

--- a/image/cache/chain.go
+++ b/image/cache/chain.go
@@ -85,15 +85,13 @@ func NewImageStore(fs store.Backend, ls store.LayerStore) (ChainStore, error) {
 			ls:     ls,
 		}
 
-		if err := imageChain.restore(); err != nil {
-			return
-		}
+		imageChain.restore()
 	})
 	return imageChain, nil
 }
 
 // restore reads all images saved in filesystem and calculate their chainID
-func (cs *chainStore) restore() error {
+func (cs *chainStore) restore() {
 	cs.Lock()
 	defer cs.Unlock()
 
@@ -136,8 +134,6 @@ func (cs *chainStore) restore() error {
 			}
 		}
 	}
-
-	return nil
 }
 
 func (cs *chainStore) GetChainLayer(id ChainID) (v1.Layer, error) {

--- a/image/distributionutil/pull.go
+++ b/image/distributionutil/pull.go
@@ -56,7 +56,7 @@ func (puller *ImagePuller) Pull(ctx context.Context, named reference.Named) (*v1
 		return nil, err
 	}
 
-	v1Image, err := puller.getRemoteImageMetadata(ctx, named, manifest.Config.Digest)
+	v1Image, err := puller.getRemoteImageMetadata(ctx, manifest.Config.Digest)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (puller *ImagePuller) Pull(ctx context.Context, named reference.Named) (*v1
 				return LayerErr
 			}
 
-			LayerErr = puller.downloadLayer(ctx, named, roLayer, descriptor)
+			LayerErr = puller.downloadLayer(ctx, roLayer, descriptor)
 			if LayerErr != nil {
 				return LayerErr
 			}
@@ -108,7 +108,7 @@ func (puller *ImagePuller) Pull(ctx context.Context, named reference.Named) (*v1
 	return &v1Image, nil
 }
 
-func (puller *ImagePuller) downloadLayer(ctx context.Context, named reference.Named, layer store.Layer, descriptor distribution.Descriptor) error {
+func (puller *ImagePuller) downloadLayer(ctx context.Context, layer store.Layer, descriptor distribution.Descriptor) error {
 	var (
 		layerStore  = puller.config.LayerStore
 		progressOut = puller.config.ProgressOutput
@@ -171,7 +171,7 @@ func (puller *ImagePuller) getRemoteManifest(context context.Context, named refe
 }
 
 // not docker image, get sealer image metadata
-func (puller *ImagePuller) getRemoteImageMetadata(context context.Context, named reference.Named, digest digest.Digest) (v1.Image, error) {
+func (puller *ImagePuller) getRemoteImageMetadata(context context.Context, digest digest.Digest) (v1.Image, error) {
 	repo := puller.repository
 	bs := repo.Blobs(context)
 	manifestImageBytes, err := bs.Get(context, digest)

--- a/image/distributionutil/push.go
+++ b/image/distributionutil/push.go
@@ -113,7 +113,7 @@ func (pusher *ImagePusher) Push(ctx context.Context, named reference.Named) erro
 		return errors.New("failed to push image, the number of layerDescriptors and pushedLayers mismatch")
 	}
 	// push sealer image metadata to registry
-	configJSON, err := pusher.putManifestConfig(ctx, named, *image)
+	configJSON, err := pusher.putManifestConfig(ctx, *image)
 	if err != nil {
 		return err
 	}
@@ -216,7 +216,7 @@ func (pusher *ImagePusher) putManifest(ctx context.Context, configJSON []byte, n
 	return err
 }
 
-func (pusher *ImagePusher) putManifestConfig(ctx context.Context, named reference.Named, image v1.Image) ([]byte, error) {
+func (pusher *ImagePusher) putManifestConfig(ctx context.Context, image v1.Image) ([]byte, error) {
 	repo := pusher.repository
 	configJSON, err := json.Marshal(image)
 	if err != nil {

--- a/logger/conn.go
+++ b/logger/conn.go
@@ -83,7 +83,7 @@ func (c *connLogger) LogWrite(when time.Time, msgText interface{}, level logLeve
 
 	//网络异常时，消息发出
 	if !c.illNetFlag {
-		err = c.println(when, msg)
+		err = c.println(msg)
 		//网络异常，通知处理网络的go程自动重连
 		if err != nil {
 			c.illNetFlag = true
@@ -142,7 +142,7 @@ func (c *connLogger) needToConnectOnMsg() bool {
 	return c.ReconnectOnMsg
 }
 
-func (c *connLogger) println(when time.Time, msg *loginfo) error {
+func (c *connLogger) println(msg *loginfo) error {
 	c.Lock()
 	defer c.Unlock()
 	ss, err := json.Marshal(msg)

--- a/logger/console.go
+++ b/logger/console.go
@@ -84,9 +84,9 @@ func (c *consoleLogger) LogWrite(when time.Time, msgText interface{}, level logL
 	}
 	switch level {
 	case LevelEmergency, LevelAlert, LevelCritical, LevelError:
-		c.printlnToStdErr(when, msg)
+		c.printlnToStdErr(msg)
 	default:
-		c.printlnToStdOut(when, msg)
+		c.printlnToStdOut(msg)
 	}
 
 	return nil
@@ -96,13 +96,13 @@ func (c *consoleLogger) Destroy() {
 
 }
 
-func (c *consoleLogger) printlnToStdOut(when time.Time, msg string) {
+func (c *consoleLogger) printlnToStdOut(msg string) {
 	c.stdOutMux.Lock()
 	defer c.stdOutMux.Unlock()
 	_, _ = common.StdOut.Write(append([]byte(msg), '\n'))
 }
 
-func (c *consoleLogger) printlnToStdErr(when time.Time, msg string) {
+func (c *consoleLogger) printlnToStdErr(msg string) {
 	c.stdErrMux.Lock()
 	defer c.stdErrMux.Unlock()
 	_, _ = common.StdErr.Write(append([]byte(msg), '\n'))

--- a/runtime/init.go
+++ b/runtime/init.go
@@ -88,7 +88,7 @@ func (d *Default) GetKubectlAndKubeconfig() error {
 	return GetKubectlAndKubeconfig(d.SSH, d.Masters[0])
 }
 
-func (d *Default) initRunner(cluster *v1.Cluster) error {
+func (d *Default) initRunner(cluster *v1.Cluster) {
 	d.SSH = ssh.NewSSHByCluster(cluster)
 	d.ClusterName = cluster.Name
 	d.SvcCIDR = cluster.Spec.Network.SvcCIDR
@@ -111,7 +111,6 @@ func (d *Default) initRunner(cluster *v1.Cluster) error {
 	d.SvcCIDR = cluster.Spec.Network.SvcCIDR
 
 	// return d.LoadMetadata()
-	return nil
 }
 func (d *Default) ConfigKubeadmOnMaster0() error {
 	var templateData string

--- a/runtime/reset.go
+++ b/runtime/reset.go
@@ -23,20 +23,12 @@ import (
 )
 
 func (d *Default) reset(cluster *v1.Cluster) error {
-	err := d.resetNodes(cluster.Spec.Nodes.IPList)
-	if err != nil {
-		logger.Error("failed to clean nodes %v", err)
-	}
-	err = d.resetMasters(cluster.Spec.Masters.IPList)
-	if err != nil {
-		logger.Error("failed to clean masters %v", err)
-	}
+	d.resetNodes(cluster.Spec.Nodes.IPList)
+	d.resetMasters(cluster.Spec.Masters.IPList)
 	return d.RecycleRegistry()
 }
-func (d *Default) resetNodes(nodes []string) error {
-	if len(nodes) == 0 {
-		return nil
-	}
+
+func (d *Default) resetNodes(nodes []string) {
 	var wg sync.WaitGroup
 	for _, node := range nodes {
 		wg.Add(1)
@@ -48,20 +40,16 @@ func (d *Default) resetNodes(nodes []string) error {
 		}(node)
 	}
 	wg.Wait()
-
-	return nil
 }
-func (d *Default) resetMasters(nodes []string) error {
-	if len(nodes) == 0 {
-		return nil
-	}
+
+func (d *Default) resetMasters(nodes []string) {
 	for _, node := range nodes {
 		if err := d.resetNode(node); err != nil {
 			logger.Error("delete master %s failed %v", node, err)
 		}
 	}
-	return nil
 }
+
 func (d *Default) resetNode(node string) error {
 	if err := d.SSH.CmdAsync(node, fmt.Sprintf(RemoteCleanMasterOrNode, vlogToStr(d.Vlog)),
 		fmt.Sprintf(RemoteRemoveAPIServerEtcHost, d.APIServer),

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -84,11 +84,8 @@ func NewDefaultRuntime(cluster *v1.Cluster) Interface {
 		return nil
 	}
 	d := &Default{imageStore: c}
-	err = d.initRunner(cluster)
-	if err != nil {
-		logger.Error("get runtime failed %v", err)
-		return nil
-	}
+	d.initRunner(cluster)
+
 	return d
 }
 

--- a/utils/archive/compress.go
+++ b/utils/archive/compress.go
@@ -133,7 +133,7 @@ func compress(paths []string, options Options) (reader io.ReadCloser, err error)
 	return pr, nil
 }
 
-func writeWhiteout(header *tar.Header, fi os.FileInfo, path string) (*tar.Header, error) {
+func writeWhiteout(header *tar.Header, fi os.FileInfo, path string) *tar.Header {
 	// overlay whiteout process
 	// this is a whiteout file
 	if fi.Mode()&os.ModeCharDevice != 0 && header.Devminor == 0 && header.Devmajor == 0 {
@@ -170,7 +170,7 @@ func writeWhiteout(header *tar.Header, fi os.FileInfo, path string) (*tar.Header
 			}
 		}
 	}
-	return woh, nil
+	return woh
 }
 
 func readWhiteout(hdr *tar.Header, path string) (bool, error) {
@@ -239,10 +239,7 @@ func writeToTarWriter(path string, tarWriter *tar.Writer, bufWriter *bufio.Write
 		// and set add Suffix WhiteoutOpaqueDir for opaque.
 		// but we still need to write its original header into tar stream,
 		// because we need to create dir on this original header.
-		woh, walkErr := writeWhiteout(header, fi, file)
-		if walkErr != nil {
-			return fmt.Errorf("failed to write white out, path: %s, err: %v", file, walkErr)
-		}
+		woh := writeWhiteout(header, fi, file)
 		walkErr = tarWriter.WriteHeader(header)
 		if walkErr != nil {
 			return fmt.Errorf("failed to write original header, path: %s, err: %v", file, walkErr)

--- a/utils/ssh/scp.go
+++ b/utils/ssh/scp.go
@@ -234,9 +234,9 @@ func (s *SSH) Copy(host, localPath, remotePath string) error {
 
 	epu.startMessage()
 	if f.IsDir() {
-		s.copyLocalDirToRemote(host, sshClient, sftpClient, localPath, remotePath, epu)
+		s.copyLocalDirToRemote(host, sftpClient, localPath, remotePath, epu)
 	} else {
-		err = s.copyLocalFileToRemote(host, sshClient, sftpClient, localPath, remotePath)
+		err = s.copyLocalFileToRemote(host, sftpClient, localPath, remotePath)
 		if err != nil {
 			epu.fail(err)
 		}
@@ -245,7 +245,7 @@ func (s *SSH) Copy(host, localPath, remotePath string) error {
 	return nil
 }
 
-func (s *SSH) copyLocalDirToRemote(host string, sshClient *ssh.Client, sftpClient *sftp.Client, localPath, remotePath string, epu *easyProgressUtil) {
+func (s *SSH) copyLocalDirToRemote(host string, sftpClient *sftp.Client, localPath, remotePath string, epu *easyProgressUtil) {
 	localFiles, err := ioutil.ReadDir(localPath)
 	if err != nil {
 		logger.Error("read local path dir failed %s %s", host, localPath)
@@ -263,9 +263,9 @@ func (s *SSH) copyLocalDirToRemote(host string, sshClient *ssh.Client, sftpClien
 				logger.Error("failed to create remote path %s:%v", rfp, err)
 				return
 			}
-			s.copyLocalDirToRemote(host, sshClient, sftpClient, lfp, rfp, epu)
+			s.copyLocalDirToRemote(host, sftpClient, lfp, rfp, epu)
 		} else {
-			err := s.copyLocalFileToRemote(host, sshClient, sftpClient, lfp, rfp)
+			err := s.copyLocalFileToRemote(host, sftpClient, lfp, rfp)
 			if err != nil {
 				errMsg := fmt.Sprintf("copy local file to remote failed %v %s %s %s", err, host, lfp, rfp)
 				epu.fail(err)
@@ -279,7 +279,7 @@ func (s *SSH) copyLocalDirToRemote(host string, sshClient *ssh.Client, sftpClien
 
 // check the remote file existence before copying
 // solve the sesion
-func (s *SSH) copyLocalFileToRemote(host string, sshClient *ssh.Client, sftpClient *sftp.Client, localPath, remotePath string) error {
+func (s *SSH) copyLocalFileToRemote(host string, sftpClient *sftp.Client, localPath, remotePath string) error {
 	var (
 		srcMd5, dstMd5 string
 	)

--- a/utils/ssh/sshcmd.go
+++ b/utils/ssh/sshcmd.go
@@ -67,11 +67,11 @@ func (s *SSH) CmdAsync(host string, cmds ...string) error {
 			doneout := make(chan bool, 1)
 			doneerr := make(chan bool, 1)
 			go func() {
-				readPipe(stderr, true)
+				readPipe(stderr)
 				doneerr <- true
 			}()
 			go func() {
-				readPipe(stdout, false)
+				readPipe(stdout)
 				doneout <- true
 			}()
 			<-doneerr
@@ -105,7 +105,7 @@ func (s *SSH) Cmd(host, cmd string) ([]byte, error) {
 	return b, nil
 }
 
-func readPipe(pipe io.Reader, isErr bool) {
+func readPipe(pipe io.Reader) {
 	r := bufio.NewReader(pipe)
 	for {
 		line, _, err := r.ReadLine()


### PR DESCRIPTION
Signed-off-by: allensun.shl <allensun.shl@alibaba-inc.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
When I apply golangci-lint with unparam rule, it throws the following error:
```
logger/conn.go:145:30: `(*connLogger).println` - `when` is unused (unparam)
func (c *connLogger) println(when time.Time, msg *loginfo) error {
                             ^
logger/console.go:99:41: `(*consoleLogger).printlnToStdOut` - `when` is unused (unparam)
func (c *consoleLogger) printlnToStdOut(when time.Time, msg string) {
                                        ^
logger/console.go:105:41: `(*consoleLogger).printlnToStdErr` - `when` is unused (unparam)
func (c *consoleLogger) printlnToStdErr(when time.Time, msg string) {
                                        ^
utils/archive/compress.go:136:83: writeWhiteout - result 1 (error) is always nil (unparam)
func writeWhiteout(header *tar.Header, fi os.FileInfo, path string) (*tar.Header, error) {
                                                                                  ^
utils/ssh/scp.go:282:50: `(*SSH).copyLocalFileToRemote` - `sshClient` is unused (unparam)
func (s *SSH) copyLocalFileToRemote(host string, sshClient *ssh.Client, sftpClient *sftp.Client, localPath, remotePath string) error {
                                                 ^
utils/ssh/sshcmd.go:108:31: `readPipe` - `isErr` is unused (unparam)
func readPipe(pipe io.Reader, isErr bool) {
                              ^
image/cache/chain.go:96:33: (*chainStore).restore - result 0 (error) is always nil (unparam)
func (cs *chainStore) restore() error {
                                ^
runtime/init.go:91:51: (*Default).initRunner - result 0 (error) is always nil (unparam)
func (d *Default) initRunner(cluster *v1.Cluster) error {
                                                  ^
runtime/reset.go:36:46: (*Default).resetNodes - result 0 (error) is always nil (unparam)
func (d *Default) resetNodes(nodes []string) error {
                                             ^
runtime/reset.go:54:48: (*Default).resetMasters - result 0 (error) is always nil (unparam)
func (d *Default) resetMasters(nodes []string) error {
                                               ^
image/distributionutil/pull.go:111:63: `(*ImagePuller).downloadLayer` - `named` is unused (unparam)
func (puller *ImagePuller) downloadLayer(ctx context.Context, named reference.Named, layer store.Layer, descriptor distribution.Descriptor) error {
                                                              ^
image/distributionutil/pull.go:174:76: `(*ImagePuller).getRemoteImageMetadata` - `named` is unused (unparam)
func (puller *ImagePuller) getRemoteImageMetadata(context context.Context, named reference.Named, digest digest.Digest) (v1.Image, error) {
                                                                           ^
image/distributionutil/push.go:219:67: `(*ImagePusher).putManifestConfig` - `named` is unused (unparam)
func (pusher *ImagePusher) putManifestConfig(ctx context.Context, named reference.Named, image v1.Image) ([]byte, error) {
                                                                  ^
apply/default_applier.go:215:57: `(*DefaultApplier).diff` - result `err` is always `nil` (unparam)
func (c *DefaultApplier) diff() (todoList []ActionName, err error) {
                                                        ^
```

### Does this pull request fix one issue?

none

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
none


### Describe how to verify it
none


### Special notes for reviews
none
