### PR TITLE
refactor: remove error log and use return to transfer information

### DIFF
--- a/apply/run.go
+++ b/apply/run.go
@@ -121,9 +121,9 @@ func (c *ClusterArgs) SetClusterArgs() error {
 }
 
 func GetClusterFileByImageName(imageName string) (cluster *v1.Cluster, err error) {
-	clusterFile := image.GetClusterFileFromImageManifest(imageName)
-	if clusterFile == "" {
-		return nil, fmt.Errorf("failed to find Clusterfile")
+	clusterFile, err := image.GetClusterFileFromImageManifest(imageName)
+	if err != nil {
+		return nil, err
 	}
 	if err := yaml.Unmarshal([]byte(clusterFile), &cluster); err != nil {
 		return nil, err

--- a/build/cloud_builder.go
+++ b/build/cloud_builder.go
@@ -108,12 +108,12 @@ func (c *CloudBuilder) InitClusterFile() error {
 		return nil
 	}
 
-	rawClusterFile := GetRawClusterFile(c.local.Image)
-	if rawClusterFile == "" {
-		return fmt.Errorf("failed to get cluster file from context or base image")
-	}
-	err := yaml.Unmarshal([]byte(rawClusterFile), &cluster)
+	rawClusterFile, err := GetRawClusterFile(c.local.Image)
 	if err != nil {
+		return err
+	}
+
+	if err := yaml.Unmarshal([]byte(rawClusterFile), &cluster); err != nil {
 		return err
 	}
 

--- a/build/lite_builder.go
+++ b/build/lite_builder.go
@@ -151,8 +151,7 @@ func (l *LiteBuilder) InitDockerAndRegistry() error {
 	r, err := utils.RunSimpleCmd(fmt.Sprintf("%s && %s", initDockerCmd, initRegistryCmd))
 	logger.Info(r)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Init docker and registry failed: %v", err))
-		return err
+		return fmt.Errorf("failed to init docker and registry: %v", err)
 	}
 	return nil
 }

--- a/image/default_image.go
+++ b/image/default_image.go
@@ -162,8 +162,7 @@ func (d DefaultImageService) Push(imageName string) error {
 func (d DefaultImageService) Login(RegistryURL, RegistryUsername, RegistryPasswd string) error {
 	err := distributionutil.Login(context.Background(), &types.AuthConfig{ServerAddress: RegistryURL, Username: RegistryUsername, Password: RegistryPasswd})
 	if err != nil {
-		logger.Error("%v authentication failed", RegistryURL)
-		return err
+		return fmt.Errorf("failed to authenticate %s: %v", RegistryURL, err)
 	}
 	if err := utils.SetDockerConfig(RegistryURL, RegistryUsername, RegistryPasswd); err != nil {
 		return err

--- a/sealer/cmd/inspect.go
+++ b/sealer/cmd/inspect.go
@@ -34,9 +34,9 @@ sealer inspect -c kubernetes:v1.18.3 to print image Clusterfile`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if clusterFilePrint {
-			cluster := image.GetClusterFileFromImageManifest(args[0])
-			if cluster == "" {
-				logger.Error("failed to find Clusterfile by image %s", args[0])
+			cluster, err := image.GetClusterFileFromImageManifest(args[0])
+			if err != nil {
+				logger.Error("failed to find Clusterfile by image %s: %v", args[0], err)
 				os.Exit(1)
 			}
 			fmt.Println(cluster)


### PR DESCRIPTION
Signed-off-by: allensun.shl <allensun.shl@alibaba-inc.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

I am afraid that there are several places misusing `returned parameters` and `log printing`. For example:
```
        if err != nil {
		logger.Error("failed to init image store, err: %s", err)
		return ""
	}
```

In this case, we used logger printing an detailed error, and just returned an empty to upper caller. Actually, upper caller is not aware of whether the function calling is successful. In general, we usually use a returned error to tell upper caller whether it works. So with the code above, there are two side effects:

* the upper caller must analyze the only returned string, to exact more information to decide what to do next. More implicit thing may occur;
* the sealer tool end user must see the detailed log to see what happened rather than returned detailed error. Quite unreasonable and produce less user experience.

#### So, maybe we should try to use the golang way to define more return parameter including the error, and use error to transfer information between calling function and called function. 


### Does this pull request fix one issue?
none

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
none


### Describe how to verify it
none


### Special notes for reviews

I think there are many cases in sealer code that contains the above issue. Firstly, when reviewing pull request, take it more strictly. Secondly, we could gradually update those codes to be better.
