### PR TITLE
refactor: move k8s client detailed calling into an encapsulated obeject

### DIFF
--- a/apply/cloud_applier.go
+++ b/apply/cloud_applier.go
@@ -82,8 +82,7 @@ func (c *CloudApplier) ScaleDownNodes(cluster *v1.Cluster) (isScaleDown bool, er
 		return false, fmt.Errorf("should not scale up and down at same time")
 	}
 
-	err = DeleteNodes(append(MastersToDelete, NodesToDelete...))
-	if err != nil {
+	if err := c.DeleteNodes(append(MastersToDelete, NodesToDelete...)); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -92,7 +91,7 @@ func (c *CloudApplier) ScaleDownNodes(cluster *v1.Cluster) (isScaleDown bool, er
 func (c *CloudApplier) Apply() error {
 	var err error
 	cluster := c.ClusterDesired
-	clusterCurrent, err := GetCurrentCluster()
+	clusterCurrent, err := c.GetCurrentCluster()
 	if err != nil {
 		return fmt.Errorf("failed to get current cluster %v", err)
 	}

--- a/apply/current_cluster.go
+++ b/apply/current_cluster.go
@@ -18,35 +18,22 @@ import (
 	"fmt"
 	"strconv"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/alibaba/sealer/client"
 	"github.com/alibaba/sealer/logger"
 	v1 "github.com/alibaba/sealer/types/api/v1"
 	"github.com/alibaba/sealer/utils"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const MasterRoleLabel = "node-role.kubernetes.io/master"
 
-func GetCurrentCluster() (*v1.Cluster, error) {
-	return getCurrentNodes()
+func (c *DefaultApplier) GetCurrentCluster() (*v1.Cluster, error) {
+	return c.getCurrentNodes()
 }
 
-func listNodes() (*corev1.NodeList, error) {
-	c, err := client.NewClientSet()
-	if err != nil {
-		return nil, fmt.Errorf("current cluster not found, %v", err)
-	}
-	nodes, err := client.ListNodes(c)
-	if err != nil {
-		return nil, fmt.Errorf("current cluster nodes not found, %v", err)
-	}
-	return nodes, nil
-}
-
-func getCurrentNodes() (*v1.Cluster, error) {
-	nodes, err := listNodes()
+func (c *DefaultApplier) getCurrentNodes() (*v1.Cluster, error) {
+	nodes, err := c.client.ListNodes()
 	if err != nil {
 		logger.Warn("%v, will create a new cluster", err)
 		return nil, nil
@@ -83,18 +70,9 @@ func getNodeAddress(node *corev1.Node) string {
 	return node.Status.Addresses[0].Address
 }
 
-func deleteNode(name string) error {
-	c, err := client.NewClientSet()
-	if err != nil {
-		logger.Info("current cluster not found, will create a new cluster %v", err)
-		return nil
-	}
-	return client.DeleteNode(c, name)
-}
-
-func DeleteNodes(nodeIPs []string) error {
+func (c *DefaultApplier) DeleteNodes(nodeIPs []string) error {
 	logger.Info("delete nodes %s", nodeIPs)
-	nodes, err := listNodes()
+	nodes, err := c.client.ListNodes()
 	if err != nil {
 		return err
 	}
@@ -103,7 +81,7 @@ func DeleteNodes(nodeIPs []string) error {
 		if addr == "" || utils.NotIn(addr, nodeIPs) {
 			continue
 		}
-		if err := deleteNode(node.Name); err != nil {
+		if err := c.client.DeleteNode(node.Name); err != nil {
 			return fmt.Errorf("failed to delete node %v", err)
 		}
 	}

--- a/apply/current_cluster_test.go
+++ b/apply/current_cluster_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestGetCurrentCluster(t *testing.T) {
+	c := &DefaultApplier{}
 	tests := []struct {
 		name    string
 		want    *v1.Cluster
@@ -49,7 +50,7 @@ func TestGetCurrentCluster(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetCurrentCluster()
+			got, err := c.GetCurrentCluster()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetCurrentCluster() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/apply/default_applier.go
+++ b/apply/default_applier.go
@@ -17,6 +17,7 @@ package apply
 import (
 	"fmt"
 
+	"github.com/alibaba/sealer/client"
 	"github.com/alibaba/sealer/common"
 	"github.com/alibaba/sealer/config"
 	"github.com/alibaba/sealer/filesystem"
@@ -46,6 +47,7 @@ type DefaultApplier struct {
 	MastersToDelete []string
 	NodesToJoin     []string
 	NodesToDelete   []string
+	client          *client.K8sClient
 }
 
 type ActionName string
@@ -183,7 +185,7 @@ func (c *DefaultApplier) Apply() (err error) {
 			return err
 		}
 
-		currentCluster, err := GetCurrentCluster()
+		currentCluster, err := c.GetCurrentCluster()
 		if err != nil {
 			return errors.Wrap(err, "get current cluster failed")
 		}
@@ -277,6 +279,12 @@ func NewDefaultApplier(cluster *v1.Cluster) (Interface, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	k8sClient, err := client.Newk8sClient()
+	if err != nil {
+		return nil, err
+	}
+
 	return &DefaultApplier{
 		ClusterDesired: cluster,
 		ImageManager:   imgSvc,
@@ -284,5 +292,6 @@ func NewDefaultApplier(cluster *v1.Cluster) (Interface, error) {
 		Guest:          gs,
 		Config:         config.NewConfiguration(cluster.Name),
 		Plugins:        plugin.NewPlugins(cluster.Name),
+		client:         k8sClient,
 	}, nil
 }

--- a/build/local_builder.go
+++ b/build/local_builder.go
@@ -18,7 +18,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/alibaba/sealer/client"
 	"github.com/alibaba/sealer/image/cache"
+	infraUtils "github.com/alibaba/sealer/infra/utils"
 	"github.com/pkg/errors"
 
 	"github.com/opencontainers/go-digest"
@@ -59,6 +61,7 @@ type LocalBuilder struct {
 	ImageService     image.Service
 	Prober           image.Prober
 	FS               store.Backend
+	client           *client.K8sClient
 	DockerImageCache *MountTarget
 	builderLayer
 }
@@ -235,7 +238,7 @@ func (l *LocalBuilder) CollectRegistryCache() error {
 	}
 	// wait resource to sync
 	time.Sleep(30 * time.Second)
-	if !IsAllPodsRunning() {
+	if !l.IsAllPodsRunning() {
 		return fmt.Errorf("cache docker image failed,cluster pod not running")
 	}
 	imageLayer := v1.Layer{
@@ -332,6 +335,32 @@ func (l *LocalBuilder) Cleanup() (err error) {
 	return err
 }
 
+func (l *LocalBuilder) IsAllPodsRunning() bool {
+	err := infraUtils.Retry(10, 5*time.Second, func() error {
+		namespacePodList, err := l.client.ListAllNamespacesPods()
+		if err != nil {
+			return err
+		}
+
+		var notRunning int
+		for _, podNamespace := range namespacePodList {
+			for _, pod := range podNamespace.PodList.Items {
+				if pod.Status.Phase != "Running" && pod.Status.Phase != "Succeeded" {
+					logger.Info(podNamespace.Namespace.Name, pod.Name, pod.Status.Phase)
+					notRunning++
+					continue
+				}
+			}
+		}
+		if notRunning > 0 {
+			logger.Info("remaining %d pod not running", notRunning)
+			return fmt.Errorf("pod not running")
+		}
+		return nil
+	})
+	return err == nil
+}
+
 func NewLocalBuilder(config *Config) (Interface, error) {
 	layerStore, err := store.NewDefaultLayerStore()
 	if err != nil {
@@ -353,6 +382,11 @@ func NewLocalBuilder(config *Config) (Interface, error) {
 		return nil, fmt.Errorf("failed to init store backend, err: %s", err)
 	}
 
+	k8sClient, err := client.Newk8sClient()
+	if err != nil {
+		return nil, err
+	}
+
 	prober := image.NewImageProber(service, config.NoCache)
 
 	return &LocalBuilder{
@@ -362,6 +396,7 @@ func NewLocalBuilder(config *Config) (Interface, error) {
 		ImageService: service,
 		Prober:       prober,
 		FS:           fs,
+		client:       k8sClient,
 		builderLayer: builderLayer{
 			// for skip golang ci
 			baseLayers: []v1.Layer{},

--- a/build/utils.go
+++ b/build/utils.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"time"
 
 	"github.com/alibaba/sealer/runtime"
 	"github.com/alibaba/sealer/utils/archive"
@@ -31,8 +30,6 @@ import (
 	"github.com/alibaba/sealer/client"
 	"github.com/alibaba/sealer/common"
 	"github.com/alibaba/sealer/image"
-	infraUtils "github.com/alibaba/sealer/infra/utils"
-	"github.com/alibaba/sealer/logger"
 	v1 "github.com/alibaba/sealer/types/api/v1"
 	"github.com/alibaba/sealer/utils"
 	"github.com/opencontainers/go-digest"
@@ -165,36 +162,6 @@ func GetRegistryBindDir() string {
 	}
 
 	return ""
-}
-
-func IsAllPodsRunning() bool {
-	err := infraUtils.Retry(10, 5*time.Second, func() error {
-		c, err := client.NewClientSet()
-		if err != nil {
-			return fmt.Errorf("failed to create k8s client %v", err)
-		}
-		namespacePodList, err := client.ListAllNamespacesPods(c)
-		if err != nil {
-			return err
-		}
-
-		var notRunning int
-		for _, podNamespace := range namespacePodList {
-			for _, pod := range podNamespace.PodList.Items {
-				if pod.Status.Phase != "Running" && pod.Status.Phase != "Succeeded" {
-					logger.Info(podNamespace.Namespace.Name, pod.Name, pod.Status.Phase)
-					notRunning++
-					continue
-				}
-			}
-		}
-		if notRunning > 0 {
-			logger.Info("remaining %d pod not running", notRunning)
-			return fmt.Errorf("pod not running")
-		}
-		return nil
-	})
-	return err == nil
 }
 
 // parse context and kubefile. return context abs path and kubefile abs path

--- a/check/checker/pod_checker.go
+++ b/check/checker/pod_checker.go
@@ -26,6 +26,7 @@ import (
 )
 
 type PodChecker struct {
+	client *client.K8sClient
 }
 
 type PodNamespaceStatus struct {
@@ -39,13 +40,7 @@ type PodNamespaceStatus struct {
 var PodNamespaceStatusList []PodNamespaceStatus
 
 func (n *PodChecker) Check() error {
-	// check if all the pod is Running
-	c, err := client.NewClientSet()
-	if err != nil {
-		logger.Info("failed to create k8s client  %v", err)
-		return nil
-	}
-	namespacePodList, err := client.ListAllNamespacesPods(c)
+	namespacePodList, err := n.client.ListAllNamespacesPods()
 	if err != nil {
 		return err
 	}
@@ -118,6 +113,12 @@ func getPodReadyStatus(pod *corev1.Pod) error {
 	return &NotFindReadyTypeError{}
 }
 
-func NewPodChecker() Checker {
-	return &PodChecker{}
+func NewPodChecker() (Checker, error) {
+	c, err := client.Newk8sClient()
+	if err != nil {
+		return nil, err
+	}
+	return &PodChecker{
+		client: c,
+	}, nil
 }

--- a/check/service/post_check.go
+++ b/check/service/post_check.go
@@ -39,7 +39,22 @@ func (d *PostCheckerService) Run() error {
 
 func (d *PostCheckerService) init() ([]checker.Checker, error) {
 	var checkerList []checker.Checker
-	checkerList = append(checkerList, checker.NewNodeChecker(), checker.NewPodChecker(), checker.NewSvcChecker())
+	nodeChecker, err := checker.NewNodeChecker()
+	if err != nil {
+		return nil, err
+	}
+
+	podChecker, err := checker.NewPodChecker()
+	if err != nil {
+		return nil, err
+	}
+
+	svcChecker, err := checker.NewSvcChecker()
+	if err != nil {
+		return nil, err
+	}
+
+	checkerList = append(checkerList, nodeChecker, podChecker, svcChecker)
 	return checkerList, nil
 }
 


### PR DESCRIPTION
Signed-off-by: allensun.shl <allensun.shl@alibaba-inc.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

1. wrap `*kubernetes.Clientset` of k8s.io/client-go/kubernetes , and construct a new object K8sClient in package client
2. make every object who need to call k8s apiserver carry an instance of K8sClient

This could make the code more object-oriented. And encapsulate all the implementation just in the closure scope the defined struct.


### Does this pull request fix one issue?
none

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
none

### Describe how to verify it
none


### Special notes for reviews
none
