### PR TITLE
test: fix an incorrect unit test case

### DIFF
--- a/build/lite/charts/charts_test.go
+++ b/build/lite/charts/charts_test.go
@@ -31,12 +31,12 @@ func TestDefaultChartsRootDir(t *testing.T) {
 		{
 			"test default charts root directory",
 			args{"my_cluster"},
-			"/var/lib/sealer/data/my_cluster/rootfs/charts",
+			"/var/lib/sealer/data/my_cluster/mount/charts",
 		},
 		{
 			"test default charts root directory 2",
 			args{"second_cluster"},
-			"/var/lib/sealer/data/second_cluster/rootfs/charts",
+			"/var/lib/sealer/data/second_cluster/mount/charts",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: allensun.shl <allensun.shl@alibaba-inc.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

When I use codecov to detect the unit test cases of sealer, I found that lots of useless and un-validated test cases are there. As result, they are redundant and bring much effort to maintain. 

```
ok  	github.com/alibaba/sealer/build/lite	0.010s	coverage: 88.9% of statements
--- FAIL: TestDefaultChartsRootDir (0.00s)
    --- FAIL: TestDefaultChartsRootDir/test_default_charts_root_directory (0.00s)
        charts_test.go:46: defaultChartsRootDir() got = /var/lib/sealer/data/my_cluster/mount/charts, want /var/lib/sealer/data/my_cluster/rootfs/charts
    --- FAIL: TestDefaultChartsRootDir/test_default_charts_root_directory_2 (0.00s)
        charts_test.go:46: defaultChartsRootDir() got = /var/lib/sealer/data/second_cluster/mount/charts, want /var/lib/sealer/data/second_cluster/rootfs/charts
```


### Does this pull request fix one issue?
none

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
none


### Describe how to verify it
none


### Special notes for reviews

We should have a good design of sealer's unit test.
