### PR TITLE
chore:remove docker client and k8s client to its dir

### DIFF
--- a/apply/default_applier.go
+++ b/apply/default_applier.go
@@ -16,8 +16,8 @@ package apply
 
 import (
 	"fmt"
+	"github.com/alibaba/sealer/client/k8s"
 
-	"github.com/alibaba/sealer/client"
 	"github.com/alibaba/sealer/common"
 	"github.com/alibaba/sealer/config"
 	"github.com/alibaba/sealer/filesystem"
@@ -47,7 +47,7 @@ type DefaultApplier struct {
 	MastersToDelete []string
 	NodesToJoin     []string
 	NodesToDelete   []string
-	client          *client.K8sClient
+	client          *k8s.K8sClient
 }
 
 type ActionName string
@@ -284,7 +284,7 @@ func NewDefaultApplier(cluster *v1.Cluster) (Interface, error) {
 		return nil, err
 	}
 
-	k8sClient, err := client.Newk8sClient()
+	k8sClient, err := k8s.Newk8sClient()
 	if err != nil {
 		logger.Warn(err)
 	}

--- a/apply/default_applier.go
+++ b/apply/default_applier.go
@@ -16,6 +16,7 @@ package apply
 
 import (
 	"fmt"
+
 	"github.com/alibaba/sealer/client/k8s"
 
 	"github.com/alibaba/sealer/common"

--- a/apply/default_applier.go
+++ b/apply/default_applier.go
@@ -47,7 +47,7 @@ type DefaultApplier struct {
 	MastersToDelete []string
 	NodesToJoin     []string
 	NodesToDelete   []string
-	client          *k8s.K8sClient
+	client          *k8s.Client
 }
 
 type ActionName string

--- a/build/local_builder.go
+++ b/build/local_builder.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/alibaba/sealer/client"
+	"github.com/alibaba/sealer/client/k8s"
 	"github.com/alibaba/sealer/image/cache"
 	"github.com/pkg/errors"
 
@@ -60,7 +60,7 @@ type LocalBuilder struct {
 	ImageService     image.Service
 	Prober           image.Prober
 	FS               store.Backend
-	client           *client.K8sClient
+	client           *k8s.K8sClient
 	DockerImageCache *MountTarget
 	builderLayer
 }
@@ -386,7 +386,7 @@ func NewLocalBuilder(config *Config) (Interface, error) {
 		return nil, fmt.Errorf("failed to init store backend, err: %s", err)
 	}
 
-	k8sClient, err := client.Newk8sClient()
+	k8sClient, err := k8s.Newk8sClient()
 	if err != nil {
 		return nil, err
 	}

--- a/build/local_builder.go
+++ b/build/local_builder.go
@@ -60,7 +60,7 @@ type LocalBuilder struct {
 	ImageService     image.Service
 	Prober           image.Prober
 	FS               store.Backend
-	client           *k8s.K8sClient
+	client           *k8s.Client
 	DockerImageCache *MountTarget
 	builderLayer
 }

--- a/build/utils.go
+++ b/build/utils.go
@@ -15,19 +15,16 @@
 package build
 
 import (
-	"context"
 	"fmt"
+	"github.com/alibaba/sealer/client/docker"
 	"io"
 	"io/ioutil"
 	"os"
 
 	"github.com/alibaba/sealer/runtime"
 	"github.com/alibaba/sealer/utils/archive"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/mount"
 
-	"github.com/alibaba/sealer/client"
 	"github.com/alibaba/sealer/common"
 	"github.com/alibaba/sealer/image"
 	v1 "github.com/alibaba/sealer/types/api/v1"
@@ -138,16 +135,13 @@ func GetRegistryBindDir() string {
 	// check bind dir
 	var registryName = runtime.RegistryName
 	var registryDest = runtime.RegistryBindDest
-	ctx := context.Background()
-	cli, err := client.NewDockerClient()
+
+	dockerClient, err := docker.NewDockerClient()
 	if err != nil {
 		return ""
 	}
 
-	opts := types.ContainerListOptions{All: true}
-	opts.Filters = filters.NewArgs()
-	opts.Filters.Add("name", registryName)
-	containers, err := cli.ContainerList(ctx, opts)
+	containers, err := dockerClient.GetContainerListByName(registryName)
 
 	if err != nil {
 		return ""

--- a/build/utils.go
+++ b/build/utils.go
@@ -16,10 +16,11 @@ package build
 
 import (
 	"fmt"
-	"github.com/alibaba/sealer/client/docker"
 	"io"
 	"io/ioutil"
 	"os"
+
+	"github.com/alibaba/sealer/client/docker"
 
 	"github.com/alibaba/sealer/runtime"
 	"github.com/alibaba/sealer/utils/archive"

--- a/check/checker/node_checker.go
+++ b/check/checker/node_checker.go
@@ -15,9 +15,9 @@
 package checker
 
 import (
+	"github.com/alibaba/sealer/client/k8s"
 	"text/template"
 
-	"github.com/alibaba/sealer/client"
 	"github.com/alibaba/sealer/common"
 	"github.com/alibaba/sealer/logger"
 
@@ -30,7 +30,7 @@ const (
 )
 
 type NodeChecker struct {
-	client *client.K8sClient
+	client *k8s.K8sClient
 }
 
 type NodeClusterStatus struct {
@@ -124,7 +124,7 @@ func getNodeStatus(node *corev1.Node) (IP string, Phase string) {
 
 func NewNodeChecker() (Checker, error) {
 	// check if all the node is ready
-	c, err := client.Newk8sClient()
+	c, err := k8s.Newk8sClient()
 	if err != nil {
 		return nil, err
 	}

--- a/check/checker/node_checker.go
+++ b/check/checker/node_checker.go
@@ -16,12 +16,10 @@ package checker
 
 import (
 	"github.com/alibaba/sealer/client/k8s"
-	"text/template"
-
 	"github.com/alibaba/sealer/common"
 	"github.com/alibaba/sealer/logger"
-
 	corev1 "k8s.io/api/core/v1"
+	"text/template"
 )
 
 const (

--- a/check/checker/node_checker.go
+++ b/check/checker/node_checker.go
@@ -15,11 +15,12 @@
 package checker
 
 import (
+	"text/template"
+
 	"github.com/alibaba/sealer/client/k8s"
 	"github.com/alibaba/sealer/common"
 	"github.com/alibaba/sealer/logger"
 	corev1 "k8s.io/api/core/v1"
-	"text/template"
 )
 
 const (

--- a/check/checker/node_checker.go
+++ b/check/checker/node_checker.go
@@ -30,7 +30,7 @@ const (
 )
 
 type NodeChecker struct {
-	client *k8s.K8sClient
+	client *k8s.Client
 }
 
 type NodeClusterStatus struct {

--- a/check/checker/pod_checker.go
+++ b/check/checker/pod_checker.go
@@ -15,18 +15,18 @@
 package checker
 
 import (
+	"github.com/alibaba/sealer/client/k8s"
 	"text/template"
 
 	"github.com/alibaba/sealer/common"
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/alibaba/sealer/client"
 	"github.com/alibaba/sealer/logger"
 )
 
 type PodChecker struct {
-	client *client.K8sClient
+	client *k8s.K8sClient
 }
 
 type PodNamespaceStatus struct {
@@ -114,7 +114,7 @@ func getPodReadyStatus(pod *corev1.Pod) error {
 }
 
 func NewPodChecker() (Checker, error) {
-	c, err := client.Newk8sClient()
+	c, err := k8s.Newk8sClient()
 	if err != nil {
 		return nil, err
 	}

--- a/check/checker/pod_checker.go
+++ b/check/checker/pod_checker.go
@@ -16,13 +16,10 @@ package checker
 
 import (
 	"github.com/alibaba/sealer/client/k8s"
-	"text/template"
-
 	"github.com/alibaba/sealer/common"
-
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/alibaba/sealer/logger"
+	corev1 "k8s.io/api/core/v1"
+	"text/template"
 )
 
 type PodChecker struct {

--- a/check/checker/pod_checker.go
+++ b/check/checker/pod_checker.go
@@ -15,11 +15,12 @@
 package checker
 
 import (
+	"text/template"
+
 	"github.com/alibaba/sealer/client/k8s"
 	"github.com/alibaba/sealer/common"
 	"github.com/alibaba/sealer/logger"
 	corev1 "k8s.io/api/core/v1"
-	"text/template"
 )
 
 type PodChecker struct {

--- a/check/checker/pod_checker.go
+++ b/check/checker/pod_checker.go
@@ -26,7 +26,7 @@ import (
 )
 
 type PodChecker struct {
-	client *k8s.K8sClient
+	client *k8s.Client
 }
 
 type PodNamespaceStatus struct {

--- a/check/checker/svc_checker.go
+++ b/check/checker/svc_checker.go
@@ -26,7 +26,7 @@ import (
 )
 
 type SvcChecker struct {
-	client *k8s.K8sClient
+	client *k8s.Client
 }
 
 type SvcNamespaceStatus struct {

--- a/check/checker/svc_checker.go
+++ b/check/checker/svc_checker.go
@@ -15,14 +15,12 @@
 package checker
 
 import (
-	"github.com/alibaba/sealer/client/k8s"
 	"text/template"
 
+	"github.com/alibaba/sealer/client/k8s"
 	"github.com/alibaba/sealer/common"
-
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/alibaba/sealer/logger"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type SvcChecker struct {

--- a/check/checker/svc_checker.go
+++ b/check/checker/svc_checker.go
@@ -15,18 +15,18 @@
 package checker
 
 import (
+	"github.com/alibaba/sealer/client/k8s"
 	"text/template"
 
 	"github.com/alibaba/sealer/common"
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/alibaba/sealer/client"
 	"github.com/alibaba/sealer/logger"
 )
 
 type SvcChecker struct {
-	client *client.K8sClient
+	client *k8s.K8sClient
 }
 
 type SvcNamespaceStatus struct {
@@ -114,7 +114,7 @@ func IsExistEndpoint(endpointList *corev1.EndpointsList, serviceName string) boo
 
 func NewSvcChecker() (Checker, error) {
 	// check if all the node is ready
-	c, err := client.Newk8sClient()
+	c, err := k8s.Newk8sClient()
 	if err != nil {
 		return nil, err
 	}

--- a/client/docker/container.go
+++ b/client/docker/container.go
@@ -1,0 +1,37 @@
+package docker
+
+import (
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+)
+
+func (d Docker) RmContainerByName(containerName string) error {
+	containers, err := d.GetContainerListByName(containerName)
+	if err != nil {
+		return err
+	}
+	for _, c := range containers {
+		err = d.cli.ContainerRemove(d.ctx, c.ID, types.ContainerRemoveOptions{
+			RemoveVolumes: true,
+			Force:         true,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d Docker) GetContainerListByName(containerName string) ([]types.Container, error) {
+	opts := types.ContainerListOptions{All: true}
+	opts.Filters = filters.NewArgs()
+	opts.Filters.Add("name", containerName)
+	containers, err := d.cli.ContainerList(d.ctx, opts)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return containers, err
+}

--- a/client/docker/container.go
+++ b/client/docker/container.go
@@ -1,3 +1,17 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package docker
 
 import (

--- a/client/docker/docker_client.go
+++ b/client/docker/docker_client.go
@@ -12,14 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package client
+package docker
 
-import "github.com/docker/docker/client"
+import (
+	"context"
+	"github.com/docker/docker/client"
+)
 
-func NewDockerClient() (*client.Client, error) {
+type Docker struct {
+	Auth     string
+	Username string
+	Password string
+	cli      *client.Client
+	ctx      context.Context
+}
+
+func NewDockerClient() (*Docker, error) {
+	ctx := context.Background()
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return nil, err
 	}
-	return cli, err
+	return &Docker{
+		cli: cli,
+		ctx: ctx,
+	}, nil
 }

--- a/client/docker/docker_client.go
+++ b/client/docker/docker_client.go
@@ -16,6 +16,7 @@ package docker
 
 import (
 	"context"
+
 	"github.com/docker/docker/client"
 )
 

--- a/client/docker/images.go
+++ b/client/docker/images.go
@@ -18,15 +18,15 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+
 	"github.com/alibaba/sealer/common"
 	"github.com/alibaba/sealer/image/reference"
+	"github.com/alibaba/sealer/logger"
 	"github.com/alibaba/sealer/utils"
 	dockerstreams "github.com/docker/cli/cli/streams"
 	"github.com/docker/docker/api/types"
-
-	"github.com/alibaba/sealer/logger"
 	dockerjsonmessage "github.com/docker/docker/pkg/jsonmessage"
-	"io"
 )
 
 func (d Docker) ImagesPull(images []string) {

--- a/client/docker/images.go
+++ b/client/docker/images.go
@@ -1,0 +1,114 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docker
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"github.com/alibaba/sealer/common"
+	"github.com/alibaba/sealer/image/reference"
+	"github.com/alibaba/sealer/utils"
+	dockerstreams "github.com/docker/cli/cli/streams"
+	"github.com/docker/docker/api/types"
+
+	"github.com/alibaba/sealer/logger"
+	dockerjsonmessage "github.com/docker/docker/pkg/jsonmessage"
+	"io"
+)
+
+func (d Docker) ImagesPull(images []string) {
+	for _, image := range utils.RemoveDuplicate(images) {
+		if image == "" {
+			continue
+		}
+		if err := d.ImagePull(image); err != nil {
+			logger.Warn(fmt.Sprintf("Image %s pull failed: %v", image, err))
+		}
+	}
+}
+
+func (d Docker) ImagesPullByImageListFile(fileName string) {
+	data, err := utils.ReadLines(fileName)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Read image list failed: %v", err))
+	}
+	d.ImagesPull(data)
+}
+
+func (d Docker) ImagesPullByList(images []string) {
+	d.ImagesPull(images)
+}
+
+func (d Docker) ImagePull(image string) error {
+	var (
+		named       reference.Named
+		err         error
+		authConfig  types.AuthConfig
+		out         io.ReadCloser
+		encodedJSON []byte
+		authStr     string
+	)
+	named, err = reference.ParseToNamed(image)
+	if err != nil {
+		logger.Warn("image information parsing failed: %v", err)
+		return err
+	}
+	var ImagePullOptions types.ImagePullOptions
+
+	authConfig, err = utils.GetDockerAuthInfoFromDocker(named.Domain())
+	if err == nil {
+		encodedJSON, err = json.Marshal(authConfig)
+		if err != nil {
+			logger.Warn("authConfig encodedJSON failed: %v", err)
+		} else {
+			authStr = base64.URLEncoding.EncodeToString(encodedJSON)
+		}
+	}
+
+	ImagePullOptions = types.ImagePullOptions{RegistryAuth: authStr}
+	out, err = d.cli.ImagePull(d.ctx, image, ImagePullOptions)
+	if err != nil {
+		logger.Warn("Image pull failed: %v", err)
+		return err
+	}
+	defer func() {
+		_ = out.Close()
+	}()
+	err = dockerjsonmessage.DisplayJSONMessagesToStream(out, dockerstreams.NewOut(common.StdOut), nil)
+	if err != nil && err != io.ErrClosedPipe {
+		logger.Warn("error occurs in display progressing, err: %s", err)
+	}
+	return nil
+}
+
+func (d Docker) DockerRmi(imageID string) error {
+	if _, err := d.cli.ImageRemove(d.ctx, imageID, types.ImageRemoveOptions{Force: true, PruneChildren: true}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d Docker) ImagesList() ([]*types.ImageSummary, error) {
+	var List []*types.ImageSummary
+	images, err := d.cli.ImageList(d.ctx, types.ImageListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for _, image := range images {
+		List = append(List, &image)
+	}
+	return List, nil
+}

--- a/client/k8s/client.go
+++ b/client/k8s/client.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/client-go/util/homedir"
 )
 
-type K8sClient struct {
+type Client struct {
 	client *kubernetes.Clientset
 }
 
@@ -42,7 +42,7 @@ type NamespaceSvc struct {
 	ServiceList *v1.ServiceList
 }
 
-func Newk8sClient() (*K8sClient, error) {
+func Newk8sClient() (*Client, error) {
 	kubeconfig := filepath.Join(common.DefaultKubeConfigDir(), "config")
 	if home := homedir.HomeDir(); home != "" {
 		kubeconfig = filepath.Join(home, ".kube", "config")
@@ -59,12 +59,12 @@ func Newk8sClient() (*K8sClient, error) {
 		return nil, err
 	}
 
-	return &K8sClient{
+	return &Client{
 		client: clientSet,
 	}, nil
 }
 
-func (c *K8sClient) ListNodes() (*v1.NodeList, error) {
+func (c *Client) ListNodes() (*v1.NodeList, error) {
 	nodes, err := c.client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get cluster nodes")
@@ -72,7 +72,7 @@ func (c *K8sClient) ListNodes() (*v1.NodeList, error) {
 	return nodes, nil
 }
 
-func (c *K8sClient) UpdateNode(node *v1.Node) (*v1.Node, error) {
+func (c *Client) UpdateNode(node *v1.Node) (*v1.Node, error) {
 	node, err := c.client.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to update cluster node")
@@ -80,14 +80,14 @@ func (c *K8sClient) UpdateNode(node *v1.Node) (*v1.Node, error) {
 	return node, nil
 }
 
-func (c *K8sClient) DeleteNode(name string) error {
+func (c *Client) DeleteNode(name string) error {
 	if err := c.client.CoreV1().Nodes().Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {
 		return errors.Wrapf(err, "failed to delete cluster node %s", name)
 	}
 	return nil
 }
 
-func (c *K8sClient) listNamespaces() (*v1.NamespaceList, error) {
+func (c *Client) listNamespaces() (*v1.NamespaceList, error) {
 	namespaceList, err := c.client.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get namespaces")
@@ -95,7 +95,7 @@ func (c *K8sClient) listNamespaces() (*v1.NamespaceList, error) {
 	return namespaceList, nil
 }
 
-func (c *K8sClient) ListAllNamespacesPods() ([]*NamespacePod, error) {
+func (c *Client) ListAllNamespacesPods() ([]*NamespacePod, error) {
 	namespaceList, err := c.listNamespaces()
 	if err != nil {
 		return nil, err
@@ -116,7 +116,7 @@ func (c *K8sClient) ListAllNamespacesPods() ([]*NamespacePod, error) {
 	return namespacePodList, nil
 }
 
-func (c *K8sClient) ListAllNamespacesSvcs() ([]*NamespaceSvc, error) {
+func (c *Client) ListAllNamespacesSvcs() ([]*NamespaceSvc, error) {
 	namespaceList, err := c.listNamespaces()
 	if err != nil {
 		return nil, err
@@ -136,7 +136,7 @@ func (c *K8sClient) ListAllNamespacesSvcs() ([]*NamespaceSvc, error) {
 	return namespaceSvcList, nil
 }
 
-func (c *K8sClient) GetEndpointsList(namespace string) (*v1.EndpointsList, error) {
+func (c *Client) GetEndpointsList(namespace string) (*v1.EndpointsList, error) {
 	endpointsList, err := c.client.CoreV1().Endpoints(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get endpoint in namespace %s", namespace)
@@ -144,7 +144,7 @@ func (c *K8sClient) GetEndpointsList(namespace string) (*v1.EndpointsList, error
 	return endpointsList, nil
 }
 
-func (c *K8sClient) ListSvcs(namespace string) (*v1.ServiceList, error) {
+func (c *Client) ListSvcs(namespace string) (*v1.ServiceList, error) {
 	svcs, err := c.client.CoreV1().Services(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get all namespace pods")

--- a/client/k8s/client.go
+++ b/client/k8s/client.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package client
+package k8s
 
 import (
 	"context"

--- a/infra/container/container_image.go
+++ b/infra/container/container_image.go
@@ -32,7 +32,7 @@ func (c *DockerProvider) DeleteImageResource(imageID string) error {
 }
 
 func (c *DockerProvider) PrepareImageResource() error {
-	// if exist, only set id no need to pull
+	// if existed, only set id no need to pull
 	if imageID := c.GetImageIDByName(c.ImageResource.DefaultName); imageID != "" {
 		logger.Info("image %s already exists", c.ImageResource.DefaultName)
 		c.ImageResource.ID = imageID

--- a/infra/container/provider_client.go
+++ b/infra/container/provider_client.go
@@ -17,10 +17,11 @@ package container
 import (
 	"context"
 	"fmt"
-	"github.com/docker/docker/client"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/docker/docker/client"
 
 	"github.com/alibaba/sealer/utils/ssh"
 

--- a/infra/container/provider_client.go
+++ b/infra/container/provider_client.go
@@ -17,11 +17,11 @@ package container
 import (
 	"context"
 	"fmt"
+	"github.com/docker/docker/client"
 	"os"
 	"strconv"
 	"time"
 
-	dockerClient "github.com/alibaba/sealer/client"
 	"github.com/alibaba/sealer/utils/ssh"
 
 	"github.com/alibaba/sealer/common"
@@ -29,7 +29,6 @@ import (
 	v1 "github.com/alibaba/sealer/types/api/v1"
 	"github.com/alibaba/sealer/utils"
 	"github.com/docker/docker/api/types/mount"
-	"github.com/docker/docker/client"
 )
 
 type DockerProvider struct {
@@ -381,7 +380,10 @@ func (c *DockerProvider) CleanUp() error {
 
 func NewClientWithCluster(cluster *v1.Cluster) (*DockerProvider, error) {
 	ctx := context.Background()
-	cli, err := dockerClient.NewDockerClient()
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return nil, err
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/labels.go
+++ b/plugin/labels.go
@@ -16,8 +16,9 @@ package plugin
 
 import (
 	"fmt"
-	"github.com/alibaba/sealer/client/k8s"
 	"strings"
+
+	"github.com/alibaba/sealer/client/k8s"
 
 	"github.com/alibaba/sealer/logger"
 

--- a/plugin/labels.go
+++ b/plugin/labels.go
@@ -16,9 +16,9 @@ package plugin
 
 import (
 	"fmt"
+	"github.com/alibaba/sealer/client/k8s"
 	"strings"
 
-	"github.com/alibaba/sealer/client"
 	"github.com/alibaba/sealer/logger"
 
 	v1 "k8s.io/api/core/v1"
@@ -45,7 +45,7 @@ LabelsNodes.data key = ip
 */
 type LabelsNodes struct {
 	data   map[string][]label
-	client *client.K8sClient
+	client *k8s.K8sClient
 }
 
 type label struct {
@@ -54,7 +54,7 @@ type label struct {
 }
 
 func NewLabelsNodes() (Interface, error) {
-	c, err := client.Newk8sClient()
+	c, err := k8s.Newk8sClient()
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/labels.go
+++ b/plugin/labels.go
@@ -45,7 +45,7 @@ LabelsNodes.data key = ip
 */
 type LabelsNodes struct {
 	data   map[string][]label
-	client *k8s.K8sClient
+	client *k8s.Client
 }
 
 type label struct {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
as we see, sealer will use many client such as k8s client and docker client. so i move it to its own dir with the name. 

- 1, move k8s client 
- 2, move docker client

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
