### PR TITLE
feature: add without base option for sealer build

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -31,6 +31,7 @@ func NewLocalBuilder(config *Config) (Interface, error) {
 	return &local.Builder{
 		BuildType: config.BuildType,
 		NoCache:   config.NoCache,
+		NoBase:    config.NoBase,
 	}, nil
 }
 
@@ -43,6 +44,7 @@ func NewCloudBuilder(config *Config) (Interface, error) {
 	return &cloud.Builder{
 		BuildType:          config.BuildType,
 		NoCache:            config.NoCache,
+		NoBase:             config.NoBase,
 		Provider:           provider,
 		TmpClusterFilePath: common.TmpClusterfile,
 	}, nil
@@ -52,5 +54,6 @@ func NewLiteBuilder(config *Config) (Interface, error) {
 	return &lite.Builder{
 		BuildType: config.BuildType,
 		NoCache:   config.NoCache,
+		NoBase:    config.NoBase,
 	}, nil
 }

--- a/build/build.go
+++ b/build/build.go
@@ -52,8 +52,8 @@ func NewCloudBuilder(config *Config) (Interface, error) {
 
 func NewLiteBuilder(config *Config) (Interface, error) {
 	return &lite.Builder{
-		BuildType: config.BuildType,
-		NoCache:   config.NoCache,
-		NoBase:    config.NoBase,
+		BuildType:   config.BuildType,
+		NoCache:     config.NoCache,
+		NoBase:      config.NoBase,
 	}, nil
 }

--- a/build/build.go
+++ b/build/build.go
@@ -52,8 +52,8 @@ func NewCloudBuilder(config *Config) (Interface, error) {
 
 func NewLiteBuilder(config *Config) (Interface, error) {
 	return &lite.Builder{
-		BuildType:   config.BuildType,
-		NoCache:     config.NoCache,
-		NoBase:      config.NoBase,
+		BuildType: config.BuildType,
+		NoCache:   config.NoCache,
+		NoBase:    config.NoBase,
 	}, nil
 }

--- a/build/buildkit/buildimage/build_image.go
+++ b/build/buildkit/buildimage/build_image.go
@@ -119,7 +119,7 @@ func (b BuildImage) genNewLayer(layerType, layerValue, filepath string) (v1.Laye
 	return imageLayer, nil
 }
 
-func (b BuildImage) SaveBuildImage(name string) error {
+func (b BuildImage) SaveBuildImage(name string, noBase bool) error {
 	cluster, err := b.getImageCluster()
 	if err != nil {
 		return err
@@ -129,7 +129,7 @@ func (b BuildImage) SaveBuildImage(name string) error {
 	if err != nil {
 		return fmt.Errorf("failed to set image metadata, err: %v", err)
 	}
-	layers, err := b.collectLayers()
+	layers, err := b.collectLayers(noBase)
 	if err != nil {
 		return err
 	}
@@ -145,8 +145,14 @@ func (b BuildImage) SaveBuildImage(name string) error {
 	return nil
 }
 
-func (b BuildImage) collectLayers() ([]v1.Layer, error) {
-	layers := append(b.BaseLayers, b.NewLayers...)
+func (b BuildImage) collectLayers(noBase bool) ([]v1.Layer, error) {
+	var layers []v1.Layer
+
+	if noBase {
+		layers = b.NewLayers
+	} else {
+		layers = append(b.BaseLayers, b.NewLayers...)
+	}
 
 	if !b.NeedCacheRegistry {
 		return layers, nil

--- a/build/buildkit/buildimage/build_image.go
+++ b/build/buildkit/buildimage/build_image.go
@@ -16,9 +16,11 @@ package buildimage
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
+	"github.com/alibaba/sealer/utils"
+
+	"github.com/alibaba/sealer/pkg/runtime"
 	v2 "github.com/alibaba/sealer/types/api/v2"
 
 	"github.com/alibaba/sealer/build/buildkit/buildinstruction"
@@ -27,7 +29,6 @@ import (
 	"github.com/alibaba/sealer/image/store"
 	"github.com/alibaba/sealer/logger"
 	v1 "github.com/alibaba/sealer/types/api/v1"
-	"github.com/alibaba/sealer/utils"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 )
@@ -39,14 +40,14 @@ const (
 // BuildImage this struct aims to provide image object in build stage
 // include handle layers,save build images to system.
 type BuildImage struct {
-	NeedCacheRegistry bool
-	RawImage          *v1.Image
-	BaseLayers        []v1.Layer
-	NewLayers         []v1.Layer
-	ImageStore        store.ImageStore
-	LayerStore        store.LayerStore
-	ImageService      image.Service
-	RootfsMountInfo   *buildinstruction.MountTarget
+	RawImage        *v1.Image
+	BaseLayers      []v1.Layer
+	NewLayers       []v1.Layer
+	ImageStore      store.ImageStore
+	LayerStore      store.LayerStore
+	ImageService    image.Service
+	RootfsMountInfo *buildinstruction.MountTarget
+	ImageMataData   *runtime.Metadata
 }
 
 func (b BuildImage) ExecBuild(ctx Context) error {
@@ -119,7 +120,37 @@ func (b BuildImage) genNewLayer(layerType, layerValue, filepath string) (v1.Laye
 	return imageLayer, nil
 }
 
-func (b BuildImage) SaveBuildImage(name string, noBase bool) error {
+func (b BuildImage) checkImageMataData() error {
+	lowerLayers := buildinstruction.GetBaseLayersPath(b.NewLayers)
+	target, err := buildinstruction.NewMountTarget("", "", lowerLayers)
+	if err != nil {
+		return err
+	}
+	err = target.TempMount()
+	if err != nil {
+		return err
+	}
+	defer target.CleanUp()
+	// if rootfs metadata changed,will overwrite it.
+	kv := getKubeVersion(target.GetMountTarget())
+	if b.ImageMataData.KubeVersion == kv {
+		return nil
+	}
+
+	b.ImageMataData.KubeVersion = kv
+	mf := filepath.Join(b.RootfsMountInfo.GetMountTarget(), common.DefaultMetadataName)
+	if err = utils.MarshalJSONToFile(mf, b.ImageMataData); err != nil {
+		return fmt.Errorf("failed to set image Metadata file, err: %v", err)
+	}
+
+	return nil
+}
+func (b BuildImage) SaveBuildImage(name string, opts SaveOpts) error {
+	err := b.checkImageMataData()
+	if err != nil {
+		return err
+	}
+
 	cluster, err := b.getImageCluster()
 	if err != nil {
 		return err
@@ -129,7 +160,8 @@ func (b BuildImage) SaveBuildImage(name string, noBase bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to set image metadata, err: %v", err)
 	}
-	layers, err := b.collectLayers(noBase)
+
+	layers, err := b.collectLayers(opts)
 	if err != nil {
 		return err
 	}
@@ -145,48 +177,32 @@ func (b BuildImage) SaveBuildImage(name string, noBase bool) error {
 	return nil
 }
 
-func (b BuildImage) collectLayers(noBase bool) ([]v1.Layer, error) {
+func (b BuildImage) collectLayers(opts SaveOpts) ([]v1.Layer, error) {
 	var layers []v1.Layer
 
-	if noBase {
+	if opts.WithoutBase {
 		layers = b.NewLayers
 	} else {
 		layers = append(b.BaseLayers, b.NewLayers...)
 	}
 
-	if !b.NeedCacheRegistry {
-		return layers, nil
-	}
-
-	layer, err := b.collectRegistryCache()
+	layer, err := b.collectRootfsDiff()
 	if err != nil {
 		return nil, err
 	}
 	if layer.ID == "" {
-		logger.Warn("registry cache content not found")
+		logger.Warn("no rootfs diff content found")
 		return layers, nil
 	}
 	layers = append(layers, layer)
 	return layers, nil
 }
 
-func (b BuildImage) collectRegistryCache() (v1.Layer, error) {
+func (b BuildImage) collectRootfsDiff() (v1.Layer, error) {
 	var layer v1.Layer
 	upper := b.RootfsMountInfo.GetMountUpper()
 
-	tmp, err := utils.MkTmpdir()
-	if err != nil {
-		return layer, fmt.Errorf("failed to add upper layer to image, %v", err)
-	}
-	defer utils.CleanDirs(tmp)
-	if utils.IsFileExist(filepath.Join(upper, common.RegistryDirName)) {
-		err = os.Rename(filepath.Join(upper, common.RegistryDirName), filepath.Join(tmp, common.RegistryDirName))
-		if err != nil {
-			return layer, fmt.Errorf("failed to add upper layer to image, %v", err)
-		}
-	}
-
-	layer, err = b.genNewLayer(common.BaseImageLayerType, common.RegistryLayerValue, tmp)
+	layer, err := b.genNewLayer(common.BaseImageLayerType, common.RootfsLayerValue, upper)
 	if err != nil {
 		return layer, fmt.Errorf("failed to register layer, err: %v", err)
 	}
@@ -219,10 +235,6 @@ func (b BuildImage) updateImageIDAndSaveImage(name string) error {
 }
 
 func (b BuildImage) Cleanup() error {
-	if !b.NeedCacheRegistry {
-		return nil
-	}
-
 	b.RootfsMountInfo.CleanUp()
 	return nil
 }
@@ -273,22 +285,25 @@ func NewBuildImage(kubefileName string) (Interface, error) {
 	if len(baseLayers)+len(newLayers) > maxLayerDeep {
 		return nil, errors.New("current number of layers exceeds 128 layers")
 	}
-	need := CacheDockerImage(layer0.Value, newLayers)
-	if need {
-		mountInfo, err = GetRootfsMountInfo(baseLayers)
-		if err != nil {
-			return nil, err
-		}
+
+	mountInfo, err = GetRootfsMountInfo(baseLayers)
+	if err != nil {
+		return nil, err
+	}
+
+	meta, err := runtime.LoadMetadata(filepath.Join(mountInfo.GetMountTarget()))
+	if err != nil {
+		return nil, err
 	}
 
 	return &BuildImage{
-		RawImage:          rawImage,
-		ImageStore:        imageStore,
-		LayerStore:        layerStore,
-		ImageService:      service,
-		BaseLayers:        baseLayers,
-		NewLayers:         newLayers,
-		NeedCacheRegistry: need,
-		RootfsMountInfo:   mountInfo,
+		RawImage:        rawImage,
+		ImageStore:      imageStore,
+		LayerStore:      layerStore,
+		ImageService:    service,
+		BaseLayers:      baseLayers,
+		NewLayers:       newLayers,
+		RootfsMountInfo: mountInfo,
+		ImageMataData:   meta,
 	}, nil
 }

--- a/build/buildkit/buildimage/build_image.go
+++ b/build/buildkit/buildimage/build_image.go
@@ -120,7 +120,7 @@ func (b BuildImage) genNewLayer(layerType, layerValue, filepath string) (v1.Laye
 	return imageLayer, nil
 }
 
-func (b BuildImage) checkImageMataData() error {
+func (b BuildImage) checkImageMetadata() error {
 	lowerLayers := buildinstruction.GetBaseLayersPath(b.NewLayers)
 	target, err := buildinstruction.NewMountTarget("", "", lowerLayers)
 	if err != nil {
@@ -146,7 +146,7 @@ func (b BuildImage) checkImageMataData() error {
 	return nil
 }
 func (b BuildImage) SaveBuildImage(name string, opts SaveOpts) error {
-	err := b.checkImageMataData()
+	err := b.checkImageMetadata()
 	if err != nil {
 		return err
 	}

--- a/build/buildkit/buildimage/config.go
+++ b/build/buildkit/buildimage/config.go
@@ -20,3 +20,8 @@ type Context struct {
 	//cache flag,will change for each layer ctx
 	UseCache bool
 }
+
+type SaveOpts struct {
+	WithoutBase bool
+	Labels      map[string]string
+}

--- a/build/buildkit/buildimage/image_interface.go
+++ b/build/buildkit/buildimage/image_interface.go
@@ -16,6 +16,6 @@ package buildimage
 
 type Interface interface {
 	ExecBuild(ctx Context) error
-	SaveBuildImage(name string, noBase bool) error
+	SaveBuildImage(name string, opts SaveOpts) error
 	Cleanup() error
 }

--- a/build/buildkit/buildimage/image_interface.go
+++ b/build/buildkit/buildimage/image_interface.go
@@ -16,6 +16,6 @@ package buildimage
 
 type Interface interface {
 	ExecBuild(ctx Context) error
-	SaveBuildImage(name string) error
+	SaveBuildImage(name string, noBase bool) error
 	Cleanup() error
 }

--- a/build/buildkit/buildlayer/layerutils/charts/helm.go
+++ b/build/buildkit/buildlayer/layerutils/charts/helm.go
@@ -51,14 +51,6 @@ func RenderHelmChart(chartPath string) (map[string]string, error) {
 		return nil, err
 	}
 
-	/*
-		values := map[string]interface{}{
-			"Release": map[string]interface{}{
-				"Name": "dryrun",
-			},
-			"Values": ch.Values,
-		}
-	*/
 	options := chartutil.ReleaseOptions{
 		Name: "dryrun",
 	}
@@ -73,10 +65,6 @@ func RenderHelmChart(chartPath string) (map[string]string, error) {
 		logrus.Debugf("values is %s", b)
 		return nil, fmt.Errorf("render helm chart error %s", err.Error())
 	}
-
-	//for k, v := range content {
-	//	fmt.Println(k, v)
-	//}
 
 	return content, nil
 }

--- a/build/cloud/cloud_builder.go
+++ b/build/cloud/cloud_builder.go
@@ -203,7 +203,7 @@ func (c *Builder) runBuildCommands() (err error) {
 	build := fmt.Sprintf(common.BuildClusterCmd, common.RemoteSealerPath,
 		filepath.Base(c.KubeFileName), c.ImageNamed.Raw(), common.LocalBuild, ".")
 	if c.NoBase {
-		build = fmt.Sprintf("%s %s", build, "--no-base=true")
+		build = fmt.Sprintf("%s %s", build, "--base=false")
 	}
 	if c.NoCache {
 		build = fmt.Sprintf("%s %s", build, "--no-cache=true")

--- a/build/cloud/cloud_builder.go
+++ b/build/cloud/cloud_builder.go
@@ -41,6 +41,7 @@ import (
 type Builder struct {
 	BuildType          string
 	NoCache            bool
+	NoBase             bool
 	Provider           string
 	TmpClusterFilePath string
 	ImageNamed         reference.Named
@@ -201,6 +202,12 @@ func (c *Builder) runBuildCommands() (err error) {
 	workdir := fmt.Sprintf(common.DefaultWorkDir, c.Cluster.Name)
 	build := fmt.Sprintf(common.BuildClusterCmd, common.RemoteSealerPath,
 		filepath.Base(c.KubeFileName), c.ImageNamed.Raw(), common.LocalBuild, ".")
+	if c.NoBase {
+		build = fmt.Sprintf("%s %s", build, "--no-base=true")
+	}
+	if c.NoCache {
+		build = fmt.Sprintf("%s %s", build, "--no-cache=true")
+	}
 
 	if c.Provider == common.AliCloud {
 		push := fmt.Sprintf(common.PushImageCmd, common.RemoteSealerPath,

--- a/build/config.go
+++ b/build/config.go
@@ -15,8 +15,8 @@
 package build
 
 type Config struct {
-	BuildType string
-	NoCache   bool
-	NoBase    bool
-	ImageName string
+	BuildType   string
+	NoCache     bool
+	NoBase      bool
+	ImageName   string
 }

--- a/build/config.go
+++ b/build/config.go
@@ -15,8 +15,8 @@
 package build
 
 type Config struct {
-	BuildType   string
-	NoCache     bool
-	NoBase      bool
-	ImageName   string
+	BuildType string
+	NoCache   bool
+	NoBase    bool
+	ImageName string
 }

--- a/build/config.go
+++ b/build/config.go
@@ -17,5 +17,6 @@ package build
 type Config struct {
 	BuildType string
 	NoCache   bool
+	NoBase    bool
 	ImageName string
 }

--- a/build/lite/lite_builder.go
+++ b/build/lite/lite_builder.go
@@ -96,7 +96,10 @@ func (l *Builder) ExecBuild() error {
 
 func (l *Builder) SaveBuildImage() error {
 	imageName := l.ImageNamed.Raw()
-	err := l.BuildImage.SaveBuildImage(imageName, l.NoBase)
+
+	err := l.BuildImage.SaveBuildImage(imageName, buildimage.SaveOpts{
+		WithoutBase: l.NoBase,
+	})
 	if err != nil {
 		return err
 	}

--- a/build/lite/lite_builder.go
+++ b/build/lite/lite_builder.go
@@ -24,6 +24,7 @@ import (
 type Builder struct {
 	BuildType    string
 	NoCache      bool
+	NoBase       bool
 	ImageNamed   reference.Named
 	Context      string
 	KubeFileName string
@@ -95,7 +96,7 @@ func (l *Builder) ExecBuild() error {
 
 func (l *Builder) SaveBuildImage() error {
 	imageName := l.ImageNamed.Raw()
-	err := l.BuildImage.SaveBuildImage(imageName)
+	err := l.BuildImage.SaveBuildImage(imageName, l.NoBase)
 	if err != nil {
 		return err
 	}

--- a/build/local/local_builder.go
+++ b/build/local/local_builder.go
@@ -30,6 +30,7 @@ import (
 type Builder struct {
 	BuildType    string
 	NoCache      bool
+	NoBase       bool
 	ImageNamed   reference.Named
 	Context      string
 	KubeFileName string
@@ -153,7 +154,7 @@ func (l *Builder) IsAllPodsRunning(k8sClient *k8s.Client) bool {
 
 func (l *Builder) SaveBuildImage() error {
 	imageName := l.ImageNamed.Raw()
-	err := l.BuildImage.SaveBuildImage(imageName)
+	err := l.BuildImage.SaveBuildImage(imageName, l.NoBase)
 	if err != nil {
 		return err
 	}

--- a/build/local/local_builder.go
+++ b/build/local/local_builder.go
@@ -154,7 +154,10 @@ func (l *Builder) IsAllPodsRunning(k8sClient *k8s.Client) bool {
 
 func (l *Builder) SaveBuildImage() error {
 	imageName := l.ImageNamed.Raw()
-	err := l.BuildImage.SaveBuildImage(imageName, l.NoBase)
+
+	err := l.BuildImage.SaveBuildImage(imageName, buildimage.SaveOpts{
+		WithoutBase: l.NoBase,
+	})
 	if err != nil {
 		return err
 	}

--- a/common/common.go
+++ b/common/common.go
@@ -32,7 +32,7 @@ const (
 	CMDCOMMAND         = "CMD"
 	ENVCOMMAND         = "ENV"
 	BaseImageLayerType = "BASE"
-	RegistryLayerValue = "registry cache"
+	RootfsLayerValue   = "rootfs cache"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/alibaba/sealer
 go 1.14
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/aliyun/alibaba-cloud-sdk-go v1.61.985
 	github.com/distribution/distribution/v3 v3.0.0-20211125133600-cc4627fc6e5f
 	github.com/docker/cli v20.10.6+incompatible

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -36,6 +36,8 @@ type Metadata struct {
 	Version string `json:"version"`
 	Arch    string `json:"arch"`
 	Variant string `json:"variant"`
+	//KubeVersion is a SemVer constraint specifying the version of Kubernetes required.
+	KubeVersion string `json:"kubeVersion"`
 }
 
 type KubeadmRuntime struct {

--- a/pkg/runtime/utils.go
+++ b/pkg/runtime/utils.go
@@ -134,7 +134,8 @@ func GetKubectlAndKubeconfig(ssh ssh.Interface, host string) error {
 }
 
 // LoadMetadata :read metadata via cluster image name.
-func LoadMetadata(metadataPath string) (*Metadata, error) {
+func LoadMetadata(rootfs string) (*Metadata, error) {
+	metadataPath := filepath.Join(rootfs, common.DefaultMetadataName)
 	var metadataFile []byte
 	var err error
 	var md Metadata
@@ -142,7 +143,7 @@ func LoadMetadata(metadataPath string) (*Metadata, error) {
 		return nil, nil
 	}
 
-	metadataFile, err = ioutil.ReadFile(path.Clean(metadataPath))
+	metadataFile, err = ioutil.ReadFile(filepath.Clean(metadataPath))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read CloudImage metadata %v", err)
 	}
@@ -160,7 +161,7 @@ func GetCloudImagePlatform(rootfs string) (cp ocispecs.Platform) {
 		OS:           "linux",
 		Variant:      "",
 	}
-	meta, err := LoadMetadata(filepath.Join(rootfs, common.DefaultMetadataName))
+	meta, err := LoadMetadata(rootfs)
 	if err != nil {
 		return
 	}

--- a/sealer/cmd/build.go
+++ b/sealer/cmd/build.go
@@ -28,7 +28,7 @@ type BuildFlag struct {
 	KubefileName string
 	BuildType    string
 	NoCache      bool
-	NoBase       bool
+	Base         bool
 }
 
 var buildConfig *BuildFlag
@@ -61,7 +61,7 @@ build without base:
 			BuildType: buildConfig.BuildType,
 			NoCache:   buildConfig.NoCache,
 			ImageName: buildConfig.ImageName,
-			NoBase:    buildConfig.NoBase,
+			NoBase:    !buildConfig.Base,
 		}
 
 		builder, err := build.NewBuilder(conf)
@@ -80,7 +80,7 @@ func init() {
 	buildCmd.Flags().StringVarP(&buildConfig.KubefileName, "kubefile", "f", "Kubefile", "kubefile filepath")
 	buildCmd.Flags().StringVarP(&buildConfig.ImageName, "imageName", "t", "", "cluster image name")
 	buildCmd.Flags().BoolVar(&buildConfig.NoCache, "no-cache", false, "build without cache")
-	buildCmd.Flags().BoolVar(&buildConfig.NoBase, "no-base", false, "build without base image")
+	buildCmd.Flags().BoolVar(&buildConfig.Base, "base", true, "build with base image,default value is true.")
 	if err := buildCmd.MarkFlagRequired("imageName"); err != nil {
 		logger.Error("failed to init flag: %v", err)
 		os.Exit(1)

--- a/sealer/cmd/build.go
+++ b/sealer/cmd/build.go
@@ -28,6 +28,7 @@ type BuildFlag struct {
 	KubefileName string
 	BuildType    string
 	NoCache      bool
+	NoBase       bool
 }
 
 var buildConfig *BuildFlag
@@ -51,12 +52,16 @@ lite build:
 
 build without cache:
 	sealer build -f Kubefile -t my-kubernetes:1.19.9 --no-cache
+
+build without base:
+	sealer build -f Kubefile -t my-kubernetes:1.19.9 --no-base
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		conf := &build.Config{
 			BuildType: buildConfig.BuildType,
 			NoCache:   buildConfig.NoCache,
 			ImageName: buildConfig.ImageName,
+			NoBase:    buildConfig.NoBase,
 		}
 
 		builder, err := build.NewBuilder(conf)
@@ -75,6 +80,7 @@ func init() {
 	buildCmd.Flags().StringVarP(&buildConfig.KubefileName, "kubefile", "f", "Kubefile", "kubefile filepath")
 	buildCmd.Flags().StringVarP(&buildConfig.ImageName, "imageName", "t", "", "cluster image name")
 	buildCmd.Flags().BoolVar(&buildConfig.NoCache, "no-cache", false, "build without cache")
+	buildCmd.Flags().BoolVar(&buildConfig.NoBase, "no-base", false, "build without base image")
 	if err := buildCmd.MarkFlagRequired("imageName"); err != nil {
 		logger.Error("failed to init flag: %v", err)
 		os.Exit(1)

--- a/utils/file.go
+++ b/utils/file.go
@@ -18,6 +18,7 @@ import (
 	"archive/tar"
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -566,4 +567,16 @@ func decodeCRD(filepath string, kind string) (out interface{}, err error) {
 	}
 
 	return i, nil
+}
+
+func MarshalJSONToFile(file string, obj interface{}) error {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+
+	if err = WriteFile(file, data); err != nil {
+		return err
+	}
+	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,6 +6,7 @@ github.com/BurntSushi/toml
 # github.com/Masterminds/goutils v1.1.1
 github.com/Masterminds/goutils
 # github.com/Masterminds/semver/v3 v3.1.1
+## explicit
 github.com/Masterminds/semver/v3
 # github.com/Masterminds/sprig/v3 v3.2.2
 github.com/Masterminds/sprig/v3


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Applications Image contains applications with all dependencies except the base image, so ApplicationsImage can install to an already existing Kubernetes cluster.

add "--no-base" option for sealer build, if it is true, will only keep the application context and its docker image.

in order to keep the same with the "--no-cache" option. name it as "--no-base".

run this cmd will build app image:`sealer build -f Kubefile -t myapp:v1 -m lite . --no-base`
if want keep all images include base image, run `sealer build -f Kubefile -t myimage:v1 -m lite .`


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
link to issue #695