### PR TITLE
fix tmpl file definitely exists mount dir rather than rootfs dir

### DIFF
--- a/runtime/template.go
+++ b/runtime/template.go
@@ -238,7 +238,7 @@ func getJoinTemplateText(clusterName string) string {
 
 // return file content or defaultContent if file not exist
 func readFromFileOrDefault(clusterName, fileName, defaultContent string) string {
-	fileName = filepath.Join(common.DefaultTheClusterRootfsDir(clusterName), common.EtcDir, fileName)
+	fileName = filepath.Join(common.DefaultMountCloudImageDir(clusterName), common.EtcDir, fileName)
 	_, err := os.Stat(fileName)
 	if os.IsNotExist(err) {
 		return defaultContent


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
 When the sealer machine and the k8s-master0 machine are not the same machine
The custom tmpl file in the sealer machine is only in the mount folder, not in the rootfs folder

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
fixes #816 
### Describe how you did it
Modified to read custom tmpl files from the mount folder

### Describe how to verify it
Recompile and execute again， it works;
![image](https://user-images.githubusercontent.com/20026922/140018938-a59d4a65-6b4e-4fdc-adee-3fffac99d38c.png)
![image](https://user-images.githubusercontent.com/20026922/140019055-7c93e8c3-ecc8-4ad4-811b-676a300f6f8e.png)

### Special notes for reviews
