### PR TITLE
fix node parameter error in Clusterfile generated by apply the run command when node is empty

### DIFF
--- a/apply/run.go
+++ b/apply/run.go
@@ -95,6 +95,9 @@ func (c *ClusterArgs) SetClusterArgs() error {
 	if IsNumber(c.runArgs.Masters) && (IsNumber(c.runArgs.Nodes) || c.runArgs.Nodes == "") {
 		c.cluster.Spec.Masters.Count = c.runArgs.Masters
 		c.cluster.Spec.Nodes.Count = c.runArgs.Nodes
+		if c.runArgs.Nodes == "" {
+			c.cluster.Spec.Nodes.Count = "0"
+		}
 		if c.runArgs.Provider != "" {
 			c.cluster.Spec.Provider = c.runArgs.Provider
 			if !utils.InList(c.runArgs.Provider, []string{common.AliCloud, common.CONTAINER}) {


### PR DESCRIPTION
fix node parameter error in Clusterfile generated by apply the run command when node is empty