### PR TITLE
optimize v2 test

### DIFF
--- a/test/suites/apply/apply.go
+++ b/test/suites/apply/apply.go
@@ -85,6 +85,7 @@ func LoadPluginFromDisk(clusterFilePath string) []v1.Plugin {
 func GenerateClusterfile(clusterfile string) {
 	filepath := GetRawConfigPluginFilePath()
 	cluster := LoadClusterFileFromDisk(clusterfile)
+	cluster.Spec.Env = []string{"env=TestEnv"}
 	data, err := yaml.Marshal(cluster)
 	testhelper.CheckErr(err)
 	appendData := [][]byte{data}
@@ -122,11 +123,11 @@ func GenerateClusterfile(clusterfile string) {
 }
 
 func SealerDeleteCmd(clusterFile string) string {
-	return fmt.Sprintf("%s delete -f %s --force", settings.DefaultSealerBin, clusterFile)
+	return fmt.Sprintf("%s delete -f %s --force -d", settings.DefaultSealerBin, clusterFile)
 }
 
 func SealerApplyCmd(clusterFile string) string {
-	return fmt.Sprintf("%s apply -f %s", settings.DefaultSealerBin, clusterFile)
+	return fmt.Sprintf("%s apply -f %s -d", settings.DefaultSealerBin, clusterFile)
 }
 
 func SealerRunCmd(masters, nodes, passwd string, provider string) string {
@@ -142,7 +143,7 @@ func SealerRunCmd(masters, nodes, passwd string, provider string) string {
 	if provider != "" {
 		provider = fmt.Sprintf("--provider %s", provider)
 	}
-	return fmt.Sprintf("%s run %s %s %s %s %s", settings.DefaultSealerBin, settings.TestImageName, masters, nodes, passwd, provider)
+	return fmt.Sprintf("%s run %s %s %s %s %s -d", settings.DefaultSealerBin, settings.TestImageName, masters, nodes, passwd, provider)
 }
 
 func SealerRun(masters, nodes, passwd, provider string) {
@@ -156,7 +157,7 @@ func SealerJoinCmd(masters, nodes string) string {
 	if nodes != "" {
 		nodes = fmt.Sprintf("-n %s", nodes)
 	}
-	return fmt.Sprintf("%s join %s %s -c my-test-cluster", settings.DefaultSealerBin, masters, nodes)
+	return fmt.Sprintf("%s join %s %s -c my-test-cluster -d", settings.DefaultSealerBin, masters, nodes)
 }
 
 func SealerJoin(masters, nodes string) {

--- a/test/suites/apply/fixtures/config_plugin_for_test.yaml
+++ b/test/suites/apply/fixtures/config_plugin_for_test.yaml
@@ -72,7 +72,7 @@ spec:
   type: SHELL
   action: Originally
   data: |
-    echo "OriginallyShell was successfully run from Clusterfile"
+    echo "$env: OriginallyShell was successfully run from Clusterfile"
 ---
 apiVersion: sealer.aliyun.com/v1alpha1
 kind: Plugin
@@ -82,7 +82,7 @@ spec:
   type: SHELL
   action: PostInstall
   data: |
-    echo "PostInstallShell was successfully run from Clusterfile"
+    echo "$env: PostInstallShell was successfully run from Clusterfile"
 ---
 apiVersion: sealer.aliyun.com/v1alpha1
 kind: Plugin

--- a/test/suites/build/build.go
+++ b/test/suites/build/build.go
@@ -91,7 +91,7 @@ func (a *ArgsOfBuild) Build() string {
 	if a.BuildType == "" {
 		a.BuildType = settings.LiteBuild
 	}
-	return fmt.Sprintf("%s build -f %s -t %s -m %s %s", settings.DefaultSealerBin, a.KubeFile, a.ImageName, a.BuildType, a.Context)
+	return fmt.Sprintf("%s build -f %s -t %s -m %s %s -d", settings.DefaultSealerBin, a.KubeFile, a.ImageName, a.BuildType, a.Context)
 }
 
 func NewArgsOfBuild() *ArgsOfBuild {

--- a/test/suites/build/fixtures/cloud_build/Kubefile
+++ b/test/suites/build/fixtures/cloud_build/Kubefile
@@ -3,8 +3,8 @@ COPY Clusterfile etc
 COPY test1 .
 COPY recommended.yaml .
 COPY Plugins.yaml plugin
+COPY imageList manifests
 CMD kubectl apply -f recommended.yaml
 COPY test2 .
-RUN wget -O redis.tar.gz http://download.redis.io/releases/redis-5.0.3.tar.gz
-RUN tar zxvf redis.tar.gz
+RUN wget -O redis.tar.gz http://download.redis.io/releases/redis-5.0.3.tar.gz && tar zxvf redis.tar.gz && rm -f redis.tar.gz
 CMD kubectl get nodes

--- a/test/suites/build/fixtures/cloud_build/imageList
+++ b/test/suites/build/fixtures/cloud_build/imageList
@@ -1,0 +1,1 @@
+quay.io/tigera/operator:v1.17.4

--- a/test/suites/build/fixtures/lite_build/Kubefile
+++ b/test/suites/build/fixtures/lite_build/Kubefile
@@ -1,9 +1,8 @@
-FROM sealer-io/test:v1
+FROM sealer-io/kubernetes:v1.19.8
 COPY test1 .
 COPY recommended.yaml manifests
 COPY test2 .
 COPY test3 .
-RUN wget -O redis.tar.gz http://download.redis.io/releases/redis-5.0.3.tar.gz
-RUN tar zxvf redis.tar.gz
+RUN wget -O redis.tar.gz http://download.redis.io/releases/redis-5.0.3.tar.gz && tar zxvf redis.tar.gz && rm -f redis.tar.gz
 CMD ls -l
 COPY imageList manifests

--- a/test/suites/image/image.go
+++ b/test/suites/image/image.go
@@ -36,15 +36,15 @@ func DoImageOps(action, imageName string) {
 	cmd := ""
 	switch action {
 	case settings.SubCmdPullOfSealer:
-		cmd = fmt.Sprintf("%s pull %s", settings.DefaultSealerBin, imageName)
+		cmd = fmt.Sprintf("%s pull %s -d", settings.DefaultSealerBin, imageName)
 	case settings.SubCmdPushOfSealer:
-		cmd = fmt.Sprintf("%s push %s", settings.DefaultSealerBin, imageName)
+		cmd = fmt.Sprintf("%s push %s -d", settings.DefaultSealerBin, imageName)
 	case settings.SubCmdRmiOfSealer:
-		cmd = fmt.Sprintf("%s rmi %s", settings.DefaultSealerBin, imageName)
+		cmd = fmt.Sprintf("%s rmi %s -d", settings.DefaultSealerBin, imageName)
 	case settings.SubCmdForceRmiOfSealer:
-		cmd = fmt.Sprintf("%s rmi -f %s", settings.DefaultSealerBin, GetImageID(imageName))
+		cmd = fmt.Sprintf("%s rmi -f %s -d", settings.DefaultSealerBin, GetImageID(imageName))
 	case settings.SubCmdRunOfSealer:
-		cmd = fmt.Sprintf("%s run %s", settings.DefaultSealerBin, imageName)
+		cmd = fmt.Sprintf("%s run %s -d", settings.DefaultSealerBin, imageName)
 	case settings.SubCmdListOfSealer:
 		cmd = fmt.Sprintf("%s images", settings.DefaultSealerBin)
 	}

--- a/test/testhelper/settings/settings.go
+++ b/test/testhelper/settings/settings.go
@@ -17,6 +17,8 @@ package settings
 import (
 	"os"
 	"time"
+
+	"github.com/alibaba/sealer/logger"
 )
 
 // init test params and settings
@@ -39,4 +41,7 @@ func init() {
 	if pollingInterval == "" {
 		DefaultPollingInterval = 10
 	}
+	logger.InitLogger(logger.Config{
+		DebugMode: true,
+	})
 }


### PR DESCRIPTION
v2 Infra module has not been upgraded, and the test also temporarily shields infra test;
Because infra has not implemented V2 cluster to pull infra, and v2 Apply is compatible with v1, the test will not be upgraded to v2 for the time being.
Add debug mode to display debug logs for e2e tests.