### PR TITLE
fix `$rootfs/etc/kubeadm.yml' only partial kubeadm configuration causes failure

### DIFF
--- a/pkg/runtime/init.go
+++ b/pkg/runtime/init.go
@@ -32,7 +32,7 @@ const (
 	RemoteApplyYaml                = `echo '%s' | kubectl apply -f -`
 	RemoteCmdGetNetworkInterface   = "ls /sys/class/net"
 	RemoteCmdExistNetworkInterface = "ip addr show %s | egrep \"%s\" || true"
-	WriteKubeadmConfigCmd          = `cd %s && echo '%s' > kubeadm-config.yaml`
+	WriteKubeadmConfigCmd          = `cd %s && echo '%s' > etc/kubeadm.yml`
 	DefaultVIP                     = "10.103.97.2"
 	DefaultAPIserverDomain         = "apiserver.cluster.local"
 	DefaultRegistryPort            = 5000

--- a/pkg/runtime/masters.go
+++ b/pkg/runtime/masters.go
@@ -43,13 +43,13 @@ const (
 	RemoteUpdateEtcHosts    = `sed "s/%s/%s/g" < /etc/hosts > hosts && cp -f hosts /etc/hosts`
 	RemoteCopyKubeConfig    = `rm -rf .kube/config && mkdir -p /root/.kube && cp /etc/kubernetes/admin.conf /root/.kube/config`
 	RemoteReplaceKubeConfig = `grep -qF "apiserver.cluster.local" %s  && sed -i 's/apiserver.cluster.local/%s/' %s && sed -i 's/apiserver.cluster.local/%s/' %s`
-	RemoteJoinMasterConfig  = `echo "%s" > %s/kubeadm-join-config.yaml`
-	InitMaster115Lower      = `kubeadm init --config=%s/kubeadm-config.yaml --experimental-upload-certs`
+	RemoteJoinMasterConfig  = `echo "%s" > %s/etc/kubeadm.yml`
+	InitMaster115Lower      = `kubeadm init --config=%s/etc/kubeadm.yml --experimental-upload-certs`
 	JoinMaster115Lower      = "kubeadm join %s:6443 --token %s --discovery-token-ca-cert-hash %s --experimental-control-plane --certificate-key %s"
 	JoinNode115Lower        = "kubeadm join %s:6443 --token %s --discovery-token-ca-cert-hash %s"
-	InitMaser115Upper       = `kubeadm init --config=%s/kubeadm-config.yaml --upload-certs`
-	JoinMaster115Upper      = "kubeadm join --config=%s/kubeadm-join-config.yaml"
-	JoinNode115Upper        = "kubeadm join --config=%s/kubeadm-join-config.yaml"
+	InitMaser115Upper       = `kubeadm init --config=%s/etc/kubeadm.yml --upload-certs`
+	JoinMaster115Upper      = "kubeadm join --config=%s/etc/kubeadm.yml"
+	JoinNode115Upper        = "kubeadm join --config=%s/etc/kubeadm.yml"
 	RemoveKubeConfig        = "rm -rf /usr/bin/kube* && rm -rf ~/.kube/"
 	RemoteCleanMasterOrNode = `if which kubeadm;then kubeadm reset -f %s;fi && \
 modprobe -r ipip  && lsmod && \
@@ -132,7 +132,7 @@ func (k *KubeadmRuntime) JoinMasterCommands(master, joinCmd, hostname string) []
 		joinCommands = append(joinCommands, fmt.Sprintf(DockerLoginCommand, cf.Domain+":"+cf.Port, cf.Username, cf.Password))
 	}
 	cmdUpdateHosts := fmt.Sprintf(RemoteUpdateEtcHosts, apiServerHost,
-		getAPIServerHost(utils.GetHostIP(master), k.getAPIServerDomain()))
+		getAPIServerHost(master, k.getAPIServerDomain()))
 
 	return append(joinCommands, joinCmd, cmdUpdateHosts, RemoteCopyKubeConfig)
 }

--- a/pkg/runtime/reset.go
+++ b/pkg/runtime/reset.go
@@ -18,12 +18,18 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/alibaba/sealer/utils"
+
 	"github.com/alibaba/sealer/logger"
 )
 
 func (k *KubeadmRuntime) reset() error {
 	k.resetNodes(k.getNodesIPList())
 	k.resetMasters(k.getMasterIPList())
+	//if the executing machine is not in the cluster
+	if _, err := utils.RunSimpleCmd(fmt.Sprintf(RemoteRemoveAPIServerEtcHost, k.getAPIServerDomain())); err != nil {
+		return err
+	}
 	return k.DeleteRegistry()
 }
 

--- a/pkg/runtime/utils.go
+++ b/pkg/runtime/utils.go
@@ -117,9 +117,10 @@ func GetKubectlAndKubeconfig(ssh ssh.Interface, host string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to copy kubeconfig")
 	}
-	err = utils.AppendFile(common.EtcHosts, fmt.Sprintf("%s %s", host, common.APIServerDomain))
+	_, err = utils.RunSimpleCmd(fmt.Sprintf("cat /etc/hosts |grep '%s %s' || echo '%s %s' >> /etc/hosts",
+		host, common.APIServerDomain, host, common.APIServerDomain))
 	if err != nil {
-		return errors.Wrap(err, "failed to append master IP to etc hosts")
+		return errors.Wrap(err, "failed to add master IP to etc hosts")
 	}
 	err = ssh.Fetch(host, common.KubectlPath, common.KubectlPath)
 	if err != nil {


### PR DESCRIPTION
### Describe what this PR does / why we need it

fix `$rootfs/etc/kubeadm.yml' only partial kubeadm configuration causes failure #1046 

`etc/kubeadm.yml` instead of `kubeadm-config.yaml`,`kubeadm-join-config.yaml`

### Describe how to verify it


### Special notes for reviews
