### PR TITLE
check clean.sh file is exists and add rm /usr/bin/kube* when delete c…

### DIFF
--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -233,7 +233,10 @@ func unmountRootfs(ipList []string, cluster *v2.Cluster) error {
 			if err != nil {
 				return err
 			}
-			cmd := fmt.Sprintf("%s && %s && %s", execClean, rmRootfs, rmDockerCert)
+			cmd := fmt.Sprintf("%s && %s", rmRootfs, rmDockerCert)
+			if exists := SSH.IsFileExist(ip, fmt.Sprintf(common.DefaultClusterClearBashFile, cluster.Name)); exists {
+				cmd = fmt.Sprintf("%s && %s", execClean, cmd)
+			}
 			if mounted, _ := mount.GetRemoteMountDetails(SSH, ip, clusterRootfsDir); mounted {
 				cmd = fmt.Sprintf("umount %s && %s", clusterRootfsDir, cmd)
 			}

--- a/pkg/runtime/masters.go
+++ b/pkg/runtime/masters.go
@@ -58,8 +58,8 @@ const (
 modprobe -r ipip  && lsmod && \
 rm -rf /etc/kubernetes/ && \
 rm -rf /etc/systemd/system/kubelet.service.d && rm -rf /etc/systemd/system/kubelet.service && \
-rm -rf /usr/bin/kubeadm && rm -rf /usr/bin/kubelet-pre-start.sh && \
-rm -rf /usr/bin/kubelet && rm -rf /usr/bin/crictl && \
+rm -rf /usr/bin/kubelet-pre-start.sh && \
+rm -rf /usr/bin/kube* && rm -rf /usr/bin/crictl && \
 rm -rf /etc/cni && rm -rf /opt/cni && \
 rm -rf /var/lib/etcd && rm -rf /var/etcd 
 `


### PR DESCRIPTION

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
strengthen sealer delete process:

- skip execute clean.sh if it not exists 
- merge `rm /usr/bin/kubeadm` and `rm /usr/bin/kubelet` to `rm /usr/bin/kube*` in the RemoteCleanMasterOrNode.  This will also  delete /usr/bin/kubectl .

### Does this pull request fix one issue?
Fixes #1050 Fixes #1072 

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it
sealer delete --all

### Special notes for reviews
