### PR TITLE
fix the unmount rootfs step is not performed on the scale down node.

### DIFF
--- a/apply/processor/create.go
+++ b/apply/processor/create.go
@@ -48,7 +48,10 @@ func (c *CreateProcessor) Execute(cluster *v2.Cluster) error {
 	if err := c.initPlugin(cluster); err != nil {
 		return err
 	}
-
+	err = utils.SaveClusterInfoToFile(cluster, cluster.Name)
+	if err != nil {
+		return err
+	}
 	pipLine, err := c.GetPipeLine()
 	if err != nil {
 		return err

--- a/apply/processor/create.go
+++ b/apply/processor/create.go
@@ -94,7 +94,7 @@ func (c *CreateProcessor) RunConfig(cluster *v2.Cluster) error {
 
 func (c *CreateProcessor) MountRootfs(cluster *v2.Cluster) error {
 	hosts := append(cluster.GetMasterIPList(), cluster.GetNodeIPList()...)
-	regConfig := runtime.GetRegistryConfig(common.DefaultTheClusterRootfsDir(cluster.Name), cluster.GetMaster0Ip())
+	regConfig := runtime.GetRegistryConfig(common.DefaultTheClusterRootfsDir(cluster.Name), cluster.GetMaster0IP())
 	if utils.NotInIPList(regConfig.IP, hosts) {
 		hosts = append(hosts, regConfig.IP)
 	}

--- a/apply/processor/delete.go
+++ b/apply/processor/delete.go
@@ -17,6 +17,8 @@ package processor
 import (
 	"fmt"
 
+	"github.com/alibaba/sealer/utils"
+
 	"github.com/alibaba/sealer/pkg/plugin"
 
 	"github.com/alibaba/sealer/common"
@@ -67,7 +69,12 @@ func (d DeleteProcessor) GetPipeLine() ([]func(cluster *v2.Cluster) error, error
 }
 
 func (d DeleteProcessor) UnMountRootfs(cluster *v2.Cluster) error {
-	return d.FileSystem.UnMountRootfs(cluster)
+	hosts := append(cluster.GetMasterIPList(), cluster.GetNodeIPList()...)
+	config := runtime.GetRegistryConfig(common.DefaultTheClusterRootfsDir(cluster.Name), runtime.GetMaster0Ip(cluster))
+	if utils.NotIn(config.IP, hosts) {
+		hosts = append(hosts, config.IP)
+	}
+	return d.FileSystem.UnMountRootfs(cluster, hosts)
 }
 func (d DeleteProcessor) UnMountImage(cluster *v2.Cluster) error {
 	return d.FileSystem.UnMountImage(cluster)

--- a/apply/processor/scale.go
+++ b/apply/processor/scale.go
@@ -50,7 +50,7 @@ func (s ScaleProcessor) Execute(cluster *v2.Cluster) error {
 	if s.IsScaleUp {
 		return s.ScaleUp(cluster)
 	}
-	return s.ScaleDown()
+	return s.ScaleDown(cluster)
 }
 
 func (s ScaleProcessor) ScaleUp(cluster *v2.Cluster) error {
@@ -70,7 +70,7 @@ func (s ScaleProcessor) ScaleUp(cluster *v2.Cluster) error {
 	return nil
 }
 
-func (s ScaleProcessor) ScaleDown() error {
+func (s ScaleProcessor) ScaleDown(cluster *v2.Cluster) error {
 	err := s.Runtime.DeleteMasters(s.MastersToDelete)
 	if err != nil {
 		return err
@@ -79,7 +79,7 @@ func (s ScaleProcessor) ScaleDown() error {
 	if err != nil {
 		return err
 	}
-	return nil
+	return s.FileSystem.UnMountRootfs(cluster, append(s.MastersToDelete, s.NodesToDelete...))
 }
 
 func NewScaleProcessor(fs filesystem.Interface, masterToJoin, masterToDelete, nodeToJoin, nodeToDelete []string) (Interface, error) {

--- a/apply/processor/scale.go
+++ b/apply/processor/scale.go
@@ -17,6 +17,8 @@ package processor
 import (
 	"fmt"
 
+	"github.com/alibaba/sealer/utils"
+
 	"github.com/alibaba/sealer/common"
 	"github.com/alibaba/sealer/pkg/filesystem"
 	"github.com/alibaba/sealer/pkg/runtime"
@@ -48,6 +50,10 @@ func (s ScaleProcessor) Execute(cluster *v2.Cluster) error {
 	s.Runtime = runTime
 
 	if s.IsScaleUp {
+		err = utils.SaveClusterInfoToFile(cluster, cluster.Name)
+		if err != nil {
+			return err
+		}
 		return s.ScaleUp(cluster)
 	}
 	return s.ScaleDown(cluster)

--- a/apply/processor/upgrade.go
+++ b/apply/processor/upgrade.go
@@ -49,7 +49,7 @@ func (u UpgradeProcessor) MountRootfs(cluster *v2.Cluster) error {
 	currentHost := append(cluster.GetMasterIPList(), cluster.GetNodeIPList()...)
 	addedHost := append(u.MastersToJoin, u.NodesToJoin...)
 	_, hosts := utils.GetDiffHosts(currentHost, addedHost)
-	regConfig := runtime.GetRegistryConfig(common.DefaultTheClusterRootfsDir(cluster.Name), cluster.GetMaster0Ip())
+	regConfig := runtime.GetRegistryConfig(common.DefaultTheClusterRootfsDir(cluster.Name), cluster.GetMaster0IP())
 	if utils.NotInIPList(regConfig.IP, hosts) {
 		hosts = append(hosts, regConfig.IP)
 	}

--- a/apply/scale.go
+++ b/apply/scale.go
@@ -133,7 +133,7 @@ func deleteBaremetalNodes(cluster *v2.Cluster, scaleArgs *common.RunArgs) error 
 		return fmt.Errorf(" Parameter error: The current mode should submit iplist！")
 	}
 	//master0 machine cannot be deleted
-	if utils.InList(cluster.GetMaster0Ip(), strings.Split(scaleArgs.Masters, ",")) {
+	if utils.InList(cluster.GetMaster0IP(), strings.Split(scaleArgs.Masters, ",")) {
 		return fmt.Errorf("master0 machine cannot be deleted")
 	}
 	if scaleArgs.Masters != "" && IsIPList(scaleArgs.Masters) {

--- a/pkg/filesystem/filesystem_test.go
+++ b/pkg/filesystem/filesystem_test.go
@@ -104,7 +104,7 @@ func TestUnMount(t *testing.T) {
 			if err != nil {
 				t.Errorf("%s failed: %v", tt.name, err)
 			}
-			if err = fileSystem.UnMountRootfs(tt.arg.cluster); err != nil {
+			if err = fileSystem.UnMountRootfs(tt.arg.cluster, append(tt.arg.cluster.GetMasterIPList(), tt.arg.cluster.GetNodeIPList()...)); err != nil {
 				t.Errorf("%s failed: %v", tt.name, err)
 			}
 		})

--- a/pkg/infra/aliyun/ali_provider.go
+++ b/pkg/infra/aliyun/ali_provider.go
@@ -112,7 +112,7 @@ func (a *AliProvider) ReconcileResource(resourceKey string, action Alifunc) erro
 			return err
 		}
 		logger.Info("create resource success %s: %s", resourceKey, a.Cluster.Annotations[resourceKey])
-		return utils.SaveClusterfile(a.Cluster)
+		return utils.SaveClusterInfoToFile(a.Cluster, a.Cluster.Name)
 	}
 	return nil
 }

--- a/pkg/runtime/init.go
+++ b/pkg/runtime/init.go
@@ -54,22 +54,22 @@ func (k *KubeadmRuntime) ConfigKubeadmOnMaster0() error {
 		return err
 	}
 	cmd := fmt.Sprintf(WriteKubeadmConfigCmd, k.getRootfs(), string(bs))
-	sshClient, err := k.getHostSSHClient(k.getMaster0IP())
+	sshClient, err := k.getHostSSHClient(k.GetMaster0IP())
 	if err != nil {
 		return err
 	}
-	return sshClient.CmdAsync(k.getMaster0IP(), cmd)
+	return sshClient.CmdAsync(k.GetMaster0IP(), cmd)
 }
 
 func (k *KubeadmRuntime) generateConfigs() ([]byte, error) {
 	//getCgroupDriverFromShell need get CRISocket, so after merge
-	cGroupDriver, err := k.getCgroupDriverFromShell(k.getMaster0IP())
+	cGroupDriver, err := k.getCgroupDriverFromShell(k.GetMaster0IP())
 	if err != nil {
 		return nil, err
 	}
 	k.setCgroupDriver(cGroupDriver)
 	k.setKubeadmAPIVersion()
-	return utils.MarshalConfigsYaml(&k.InitConfiguration,
+	return utils.MarshalYamlConfigs(&k.InitConfiguration,
 		&k.ClusterConfiguration,
 		&k.KubeletConfiguration,
 		&k.KubeProxyConfiguration)
@@ -77,12 +77,12 @@ func (k *KubeadmRuntime) generateConfigs() ([]byte, error) {
 
 func (k *KubeadmRuntime) handleKubeadmConfig() {
 	//The configuration set here does not require merge
-	k.setInitAdvertiseAddress(k.getMaster0IP())
+	k.setInitAdvertiseAddress(k.GetMaster0IP())
 	k.setControlPlaneEndpoint(fmt.Sprintf("%s:6443", k.getAPIServerDomain()))
 	if k.APIServer.ExtraArgs == nil {
 		k.APIServer.ExtraArgs = make(map[string]string)
 	}
-	k.APIServer.ExtraArgs[EtcdServers] = getEtcdEndpointsWithHTTPSPrefix(k.getMasterIPList())
+	k.APIServer.ExtraArgs[EtcdServers] = getEtcdEndpointsWithHTTPSPrefix(k.GetMasterIPList())
 	k.IPVS.ExcludeCIDRs = append(k.KubeProxyConfiguration.IPVS.ExcludeCIDRs, fmt.Sprintf("%s/32", k.getVIP()))
 }
 
@@ -116,7 +116,7 @@ func (k *KubeadmRuntime) getRemoteHostName(hostIP string) (string, error) {
 }
 
 func (k *KubeadmRuntime) GenerateCert() error {
-	hostName, err := k.getRemoteHostName(k.getMaster0IP())
+	hostName, err := k.getRemoteHostName(k.GetMaster0IP())
 	if err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ func (k *KubeadmRuntime) GenerateCert() error {
 		k.getPKIPath(),
 		k.getEtcdCertPath(),
 		k.getCertSANS(),
-		k.getMaster0IP(),
+		k.GetMaster0IP(),
 		hostName,
 		k.getSvcCIDR(),
 		k.getDNSDomain(),
@@ -136,7 +136,7 @@ func (k *KubeadmRuntime) GenerateCert() error {
 	if err != nil {
 		return err
 	}
-	err = k.sendNewCertAndKey(k.getMasterIPList()[:1])
+	err = k.sendNewCertAndKey(k.GetMasterIPList()[:1])
 	if err != nil {
 		return err
 	}
@@ -144,11 +144,11 @@ func (k *KubeadmRuntime) GenerateCert() error {
 	if err != nil {
 		return err
 	}
-	return k.sendRegistryCert(k.getMasterIPList()[:1])
+	return k.sendRegistryCert(k.GetMasterIPList()[:1])
 }
 
 func (k *KubeadmRuntime) CreateKubeConfig() error {
-	hostname, err := k.getRemoteHostName(k.getMaster0IP())
+	hostname, err := k.getRemoteHostName(k.GetMaster0IP())
 	if err != nil {
 		return err
 	}
@@ -228,17 +228,17 @@ func (k *KubeadmRuntime) decodeJoinCmd(cmd string) {
 
 //InitMaster0 is
 func (k *KubeadmRuntime) InitMaster0() error {
-	ssh, err := k.getHostSSHClient(k.getMaster0IP())
+	ssh, err := k.getHostSSHClient(k.GetMaster0IP())
 	if err != nil {
 		return fmt.Errorf("failed to get master0 ssh client, %v", err)
 	}
 
-	if err := k.SendJoinMasterKubeConfigs([]string{k.getMaster0IP()}, AdminConf, ControllerConf, SchedulerConf, KubeletConf); err != nil {
+	if err := k.SendJoinMasterKubeConfigs([]string{k.GetMaster0IP()}, AdminConf, ControllerConf, SchedulerConf, KubeletConf); err != nil {
 		return err
 	}
-	apiServerHost := getAPIServerHost(k.getMaster0IP(), k.getAPIServerDomain())
+	apiServerHost := getAPIServerHost(k.GetMaster0IP(), k.getAPIServerDomain())
 	cmdAddEtcHost := fmt.Sprintf(RemoteAddEtcHosts, apiServerHost, apiServerHost)
-	err = ssh.CmdAsync(k.getMaster0IP(), cmdAddEtcHost)
+	err = ssh.CmdAsync(k.GetMaster0IP(), cmdAddEtcHost)
 	if err != nil {
 		return err
 	}
@@ -247,12 +247,12 @@ func (k *KubeadmRuntime) InitMaster0() error {
 	cmdInit := k.Command(k.getKubeVersion(), InitMaster)
 
 	// TODO skip docker version error check for test
-	output, err := ssh.Cmd(k.getMaster0IP(), cmdInit)
+	output, err := ssh.Cmd(k.GetMaster0IP(), cmdInit)
 	if err != nil {
 		return fmt.Errorf("init master0 failed, error: %s. Please clean and reinstall", err.Error())
 	}
 	k.decodeMaster0Output(output)
-	err = ssh.CmdAsync(k.getMaster0IP(), RemoteCopyKubeConfig)
+	err = ssh.CmdAsync(k.GetMaster0IP(), RemoteCopyKubeConfig)
 	if err != nil {
 		return err
 	}
@@ -264,16 +264,16 @@ func (k *KubeadmRuntime) GetKubectlAndKubeconfig() error {
 	if utils.IsFileExist(common.DefaultKubeConfigFile()) {
 		return nil
 	}
-	ssh, err := k.getHostSSHClient(k.getMaster0IP())
+	ssh, err := k.getHostSSHClient(k.GetMaster0IP())
 	if err != nil {
 		return fmt.Errorf("failed to get master0 ssh client when get kubbectl and kubeconfig %v", err)
 	}
 
-	return GetKubectlAndKubeconfig(ssh, k.getMaster0IP())
+	return GetKubectlAndKubeconfig(ssh, k.GetMaster0IP())
 }
 
 func (k *KubeadmRuntime) CopyStaticFilesTomasters() error {
-	return k.CopyStaticFiles(k.getMasterIPList())
+	return k.CopyStaticFiles(k.GetMasterIPList())
 }
 
 func (k *KubeadmRuntime) init(cluster *v2.Cluster) error {

--- a/pkg/runtime/init.go
+++ b/pkg/runtime/init.go
@@ -140,6 +140,10 @@ func (k *KubeadmRuntime) GenerateCert() error {
 	if err != nil {
 		return err
 	}
+	err = k.sendRegistryCertAndKey()
+	if err != nil {
+		return err
+	}
 	return k.sendRegistryCert(k.getMasterIPList()[:1])
 }
 

--- a/pkg/runtime/kubeadm_config_test.go
+++ b/pkg/runtime/kubeadm_config_test.go
@@ -363,7 +363,7 @@ func TestKubeadmConfig_LoadFromClusterfile(t *testing.T) {
 				t.Errorf("LoadFromClusterfile() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			logger.Info("k.InitConfiguration.Kind", k.InitConfiguration.Kind)
-			out, err := utils.MarshalConfigsToYaml(k.InitConfiguration, k.ClusterConfiguration,
+			out, err := utils.MarshalYamlConfigs(k.InitConfiguration, k.ClusterConfiguration,
 				k.JoinConfiguration, k.KubeletConfiguration, k.KubeProxyConfiguration)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MarshalConfigsToYaml() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/runtime/masters.go
+++ b/pkg/runtime/masters.go
@@ -58,8 +58,8 @@ const (
 modprobe -r ipip  && lsmod && \
 rm -rf /etc/kubernetes/ && \
 rm -rf /etc/systemd/system/kubelet.service.d && rm -rf /etc/systemd/system/kubelet.service && \
-rm -rf /usr/bin/kubelet-pre-start.sh && \
-rm -rf /usr/bin/kube* && rm -rf /usr/bin/crictl && \
+rm -rf /usr/bin/kubeadm && rm -rf /usr/bin/kubelet-pre-start.sh && \
+rm -rf /usr/bin/kubelet && rm -rf /usr/bin/crictl && \
 rm -rf /etc/cni && rm -rf /opt/cni && \
 rm -rf /var/lib/etcd && rm -rf /var/etcd 
 `
@@ -147,10 +147,10 @@ func (k *KubeadmRuntime) sendKubeConfigFile(hosts []string, kubeFile string) err
 }
 
 func (k *KubeadmRuntime) sendNewCertAndKey(hosts []string) error {
-	err := k.sendFileToHosts(hosts, k.getPKIPath(), cert.KubeDefaultCertPath)
-	if err != nil {
-		return err
-	}
+	return k.sendFileToHosts(hosts, k.getPKIPath(), cert.KubeDefaultCertPath)
+}
+
+func (k *KubeadmRuntime) sendRegistryCertAndKey() error {
 	return k.sendFileToHosts(k.getMasterIPList()[:1], k.getCertsDir(), filepath.Join(k.getRootfs(), "certs"))
 }
 

--- a/pkg/runtime/masters.go
+++ b/pkg/runtime/masters.go
@@ -124,13 +124,13 @@ func getAPIServerHost(ipAddr, APIServer string) (host string) {
 }
 
 func (k *KubeadmRuntime) JoinMasterCommands(master, joinCmd, hostname string) []string {
-	registryHost := getRegistryHost(k.getRootfs(), k.getMaster0IP())
-	apiServerHost := getAPIServerHost(k.getMaster0IP(), k.getAPIServerDomain())
+	registryHost := getRegistryHost(k.getRootfs(), k.GetMaster0IP())
+	apiServerHost := getAPIServerHost(k.GetMaster0IP(), k.getAPIServerDomain())
 	cmdAddRegistryHosts := fmt.Sprintf(RemoteAddEtcHosts, registryHost, registryHost)
 	certCMD := command.RemoteCerts(k.getCertSANS(), master, hostname, k.getSvcCIDR(), "")
 	cmdAddHosts := fmt.Sprintf(RemoteAddEtcHosts, apiServerHost, apiServerHost)
 	joinCommands := []string{cmdAddRegistryHosts, certCMD, cmdAddHosts}
-	cf := GetRegistryConfig(k.getImageMountDir(), k.getMaster0IP())
+	cf := GetRegistryConfig(k.getImageMountDir(), k.GetMaster0IP())
 	if cf.Username != "" && cf.Password != "" {
 		joinCommands = append(joinCommands, fmt.Sprintf(DockerLoginCommand, cf.Domain+":"+cf.Port, cf.Username, cf.Password))
 	}
@@ -151,7 +151,7 @@ func (k *KubeadmRuntime) sendNewCertAndKey(hosts []string) error {
 }
 
 func (k *KubeadmRuntime) sendRegistryCertAndKey() error {
-	return k.sendFileToHosts(k.getMasterIPList()[:1], k.getCertsDir(), filepath.Join(k.getRootfs(), "certs"))
+	return k.sendFileToHosts(k.GetMasterIPList()[:1], k.getCertsDir(), filepath.Join(k.getRootfs(), "certs"))
 }
 
 func (k *KubeadmRuntime) sendRegistryCert(host []string) error {
@@ -217,14 +217,14 @@ func (k *KubeadmRuntime) joinMasterConfig(masterIP string) ([]byte, error) {
 	k.Lock()
 	defer k.Unlock()
 	// TODO Using join file instead template
-	k.setAPIServerEndpoint(fmt.Sprintf("%s:6443", k.getMaster0IP()))
+	k.setAPIServerEndpoint(fmt.Sprintf("%s:6443", k.GetMaster0IP()))
 	k.setJoinAdvertiseAddress(masterIP)
 	cGroupDriver, err := k.getCgroupDriverFromShell(masterIP)
 	if err != nil {
 		return nil, err
 	}
 	k.setCgroupDriver(cGroupDriver)
-	return utils.MarshalConfigsYaml(k.JoinConfiguration, k.KubeletConfiguration)
+	return utils.MarshalYamlConfigs(k.JoinConfiguration, k.KubeletConfiguration)
 }
 
 // sendJoinCPConfig send join CP nodes configuration
@@ -281,7 +281,7 @@ func (k *KubeadmRuntime) Command(version string, name CommandType) (cmd string) 
 	// "kubeadm config migrate" command of kubeadm v1.15.x, so v1.14 not support multi network interface.
 	cmds := map[CommandType]string{
 		InitMaster: fmt.Sprintf(InitMaster115Lower, k.getRootfs()),
-		JoinMaster: fmt.Sprintf(JoinMaster115Lower, k.getMaster0IP(), k.getJoinToken(), k.getTokenCaCertHash(), k.getCertificateKey()),
+		JoinMaster: fmt.Sprintf(JoinMaster115Lower, k.GetMaster0IP(), k.getJoinToken(), k.getTokenCaCertHash(), k.getCertificateKey()),
 		JoinNode:   fmt.Sprintf(JoinNode115Lower, k.getVIP(), k.getJoinToken(), k.getTokenCaCertHash()),
 	}
 	//other version >= 1.15.x
@@ -427,7 +427,7 @@ func (k *KubeadmRuntime) deleteMaster(master string) error {
 		return fmt.Errorf("failed to delete master: %v", err)
 	}
 	remoteCleanCmd := []string{fmt.Sprintf(RemoteCleanMasterOrNode, vlogToStr(k.Vlog)),
-		fmt.Sprintf(RemoteRemoveAPIServerEtcHost, getRegistryHost(k.getRootfs(), k.getMaster0IP())),
+		fmt.Sprintf(RemoteRemoveAPIServerEtcHost, getRegistryHost(k.getRootfs(), k.GetMaster0IP())),
 		fmt.Sprintf(RemoteRemoveAPIServerEtcHost, k.getAPIServerDomain())}
 
 	//if the master to be removed is the execution machine, kubelet and ~./kube will not be removed and ApiServer host will be added.
@@ -435,7 +435,7 @@ func (k *KubeadmRuntime) deleteMaster(master string) error {
 	if err != nil || !utils.IsLocalIP(master, address) {
 		remoteCleanCmd = append(remoteCleanCmd, RemoveKubeConfig)
 	} else {
-		apiServerHost := getAPIServerHost(k.getMaster0IP(), k.getAPIServerDomain())
+		apiServerHost := getAPIServerHost(k.GetMaster0IP(), k.getAPIServerDomain())
 		remoteCleanCmd = append(remoteCleanCmd,
 			fmt.Sprintf(RemoteAddEtcHosts, apiServerHost, apiServerHost))
 	}
@@ -444,24 +444,24 @@ func (k *KubeadmRuntime) deleteMaster(master string) error {
 	}
 
 	//remove master
-	masterIPs := SliceRemoveStr(k.getMasterIPList(), master)
+	masterIPs := SliceRemoveStr(k.GetMasterIPList(), master)
 	if len(masterIPs) > 0 {
-		hostname, err := k.isHostName(k.getMaster0IP(), master)
+		hostname, err := k.isHostName(k.GetMaster0IP(), master)
 		if err != nil {
 			return err
 		}
-		master0SSH, err := k.getHostSSHClient(k.getMaster0IP())
+		master0SSH, err := k.getHostSSHClient(k.GetMaster0IP())
 		if err != nil {
 			return fmt.Errorf("failed to remove master ip: %v", err)
 		}
 
-		if err := master0SSH.CmdAsync(k.getMaster0IP(), fmt.Sprintf(KubeDeleteNode, strings.TrimSpace(hostname))); err != nil {
+		if err := master0SSH.CmdAsync(k.GetMaster0IP(), fmt.Sprintf(KubeDeleteNode, strings.TrimSpace(hostname))); err != nil {
 			return fmt.Errorf("delete node %s failed %v", hostname, err)
 		}
 	}
 	yaml := ipvs.LvsStaticPodYaml(k.getVIP(), masterIPs, "")
 	eg, _ := errgroup.WithContext(context.Background())
-	for _, node := range k.getNodesIPList() {
+	for _, node := range k.GetNodeIPList() {
 		node := node
 		eg.Go(func() error {
 			ssh, err := k.getHostSSHClient(node)
@@ -485,7 +485,7 @@ func (k *KubeadmRuntime) GetJoinTokenHashAndKey() error {
 		[upload-certs] Using certificate key:
 		8376c70aaaf285b764b3c1a588740728aff493d7c2239684e84a7367c6a437cf
 	*/
-	output, err := k.CmdToString(k.getMaster0IP(), cmd, "\r\n")
+	output, err := k.CmdToString(k.GetMaster0IP(), cmd, "\r\n")
 	if err != nil {
 		return err
 	}
@@ -498,11 +498,11 @@ func (k *KubeadmRuntime) GetJoinTokenHashAndKey() error {
 	k.CertificateKey = strings.Replace(key, "\n", "", -1)
 	cmd = fmt.Sprintf("kubeadm token create --print-join-command -v %d", k.Vlog)
 
-	ssh, err := k.getHostSSHClient(k.getMaster0IP())
+	ssh, err := k.getHostSSHClient(k.GetMaster0IP())
 	if err != nil {
 		return fmt.Errorf("failed to get join token hash and key: %v", err)
 	}
-	out, err := ssh.Cmd(k.getMaster0IP(), cmd)
+	out, err := ssh.Cmd(k.GetMaster0IP(), cmd)
 	if err != nil {
 		return fmt.Errorf("create kubeadm join token failed %v", err)
 	}

--- a/pkg/runtime/registry.go
+++ b/pkg/runtime/registry.go
@@ -51,7 +51,7 @@ func getRegistryHost(rootfs, defaultRegistry string) (host string) {
 
 // ApplyRegistry Only use this for join and init, due to the initiation operations.
 func (k *KubeadmRuntime) ApplyRegistry() error {
-	cf := GetRegistryConfig(k.getRootfs(), k.getMaster0IP())
+	cf := GetRegistryConfig(k.getRootfs(), k.GetMaster0IP())
 	ssh, err := k.getHostSSHClient(cf.IP)
 	if err != nil {
 		return fmt.Errorf("failed to get registry ssh client: %v", err)
@@ -81,18 +81,18 @@ func (k *KubeadmRuntime) ApplyRegistry() error {
 		}
 	}
 	initRegistry := fmt.Sprintf("cd %s/scripts && sh init-registry.sh %s %s", k.getRootfs(), cf.Port, fmt.Sprintf("%s/registry", k.getRootfs()))
-	registryHost := getRegistryHost(k.getRootfs(), k.getMaster0IP())
+	registryHost := getRegistryHost(k.getRootfs(), k.GetMaster0IP())
 	addRegistryHosts := fmt.Sprintf(RemoteAddEtcHosts, registryHost, registryHost)
 	if err = ssh.CmdAsync(cf.IP, initRegistry); err != nil {
 		return err
 	}
-	if err = ssh.CmdAsync(k.getMaster0IP(), addRegistryHosts); err != nil {
+	if err = ssh.CmdAsync(k.GetMaster0IP(), addRegistryHosts); err != nil {
 		return err
 	}
 	if cf.Username == "" || cf.Password == "" {
 		return nil
 	}
-	return ssh.CmdAsync(k.getMaster0IP(), fmt.Sprintf(DockerLoginCommand, cf.Domain+":"+cf.Port, cf.Username, cf.Password))
+	return ssh.CmdAsync(k.GetMaster0IP(), fmt.Sprintf(DockerLoginCommand, cf.Domain+":"+cf.Port, cf.Username, cf.Password))
 }
 
 func (r *RegistryConfig) GenerateHtPasswd() (string, error) {
@@ -140,7 +140,7 @@ func GetRegistryConfig(rootfs, defaultRegistry string) *RegistryConfig {
 }
 
 func (k *KubeadmRuntime) DeleteRegistry() error {
-	cf := GetRegistryConfig(k.getRootfs(), k.getMaster0IP())
+	cf := GetRegistryConfig(k.getRootfs(), k.GetMaster0IP())
 	delDir := fmt.Sprintf("rm -rf %s %s", RegistryMountUpper, RegistryMountWork)
 	ssh, err := k.getHostSSHClient(cf.IP)
 	if err != nil {

--- a/pkg/runtime/reset.go
+++ b/pkg/runtime/reset.go
@@ -24,8 +24,8 @@ import (
 )
 
 func (k *KubeadmRuntime) reset() error {
-	k.resetNodes(k.getNodesIPList())
-	k.resetMasters(k.getMasterIPList())
+	k.resetNodes(k.GetNodeIPList())
+	k.resetMasters(k.GetMasterIPList())
 	//if the executing machine is not in the cluster
 	if _, err := utils.RunSimpleCmd(fmt.Sprintf(RemoteRemoveAPIServerEtcHost, k.getAPIServerDomain())); err != nil {
 		return err
@@ -65,7 +65,7 @@ func (k *KubeadmRuntime) resetNode(node string) error {
 	if err := ssh.CmdAsync(node, fmt.Sprintf(RemoteCleanMasterOrNode, vlogToStr(k.Vlog)),
 		RemoveKubeConfig,
 		fmt.Sprintf(RemoteRemoveAPIServerEtcHost, k.getAPIServerDomain()),
-		fmt.Sprintf(RemoteRemoveAPIServerEtcHost, getRegistryHost(k.getRootfs(), k.getMaster0IP()))); err != nil {
+		fmt.Sprintf(RemoteRemoveAPIServerEtcHost, getRegistryHost(k.getRootfs(), k.GetMaster0IP()))); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/runtime/reset.go
+++ b/pkg/runtime/reset.go
@@ -63,6 +63,7 @@ func (k *KubeadmRuntime) resetNode(node string) error {
 		return fmt.Errorf("reset node failed %v", err)
 	}
 	if err := ssh.CmdAsync(node, fmt.Sprintf(RemoteCleanMasterOrNode, vlogToStr(k.Vlog)),
+		RemoveKubeConfig,
 		fmt.Sprintf(RemoteRemoveAPIServerEtcHost, k.getAPIServerDomain()),
 		fmt.Sprintf(RemoteRemoveAPIServerEtcHost, getRegistryHost(k.getRootfs(), k.getMaster0IP()))); err != nil {
 		return err

--- a/pkg/runtime/upgrade.go
+++ b/pkg/runtime/upgrade.go
@@ -34,15 +34,15 @@ func (k *KubeadmRuntime) upgrade() error {
 	var err error
 	binpath := filepath.Join(k.getRootfs(), `bin`)
 
-	err = k.upgradeFirstMaster(k.getMaster0IP(), binpath, k.getKubeVersion())
+	err = k.upgradeFirstMaster(k.GetMaster0IP(), binpath, k.getKubeVersion())
 	if err != nil {
 		return err
 	}
-	err = k.upgradeOtherMasters(k.getMasterIPList()[1:], binpath)
+	err = k.upgradeOtherMasters(k.GetMasterIPList()[1:], binpath)
 	if err != nil {
 		return err
 	}
-	err = k.upgradeNodes(k.getNodesIPList(), binpath)
+	err = k.upgradeNodes(k.GetNodeIPList(), binpath)
 	if err != nil {
 		return err
 	}

--- a/types/api/v2/cluster_types.go
+++ b/types/api/v2/cluster_types.go
@@ -75,7 +75,7 @@ func (in *Cluster) GetNodeIPList() []string {
 	return in.GetIPSByRole(common.NODE)
 }
 
-func (in *Cluster) GetMaster0Ip() string {
+func (in *Cluster) GetMaster0IP() string {
 	if len(in.Spec.Hosts) == 0 {
 		return ""
 	}

--- a/utils/yaml.go
+++ b/utils/yaml.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/alibaba/sealer/common"
-	v1 "github.com/alibaba/sealer/types/api/v1"
 )
 
 func UnmarshalYamlFile(file string, obj interface{}) error {
@@ -55,19 +54,6 @@ func MarshalYamlToFile(file string, obj interface{}) error {
 	return nil
 }
 
-func SaveClusterfile(cluster *v1.Cluster) error {
-	fileName := common.GetClusterWorkClusterfile(cluster.Name)
-	err := MkFileFullPathDir(fileName)
-	if err != nil {
-		return fmt.Errorf("mkdir failed %s %v", fileName, err)
-	}
-	err = MarshalYamlToFile(fileName, cluster)
-	if err != nil {
-		return fmt.Errorf("marshal cluster file failed %v", err)
-	}
-	return nil
-}
-
 func SaveClusterInfoToFile(cluster runtime.Object, clusterName string) error {
 	fileName := common.GetClusterWorkClusterfile(clusterName)
 	err := MkFileFullPathDir(fileName)
@@ -81,7 +67,7 @@ func SaveClusterInfoToFile(cluster runtime.Object, clusterName string) error {
 	return nil
 }
 
-func MarshalConfigsYaml(configs ...interface{}) ([]byte, error) {
+func MarshalYamlConfigs(configs ...interface{}) ([]byte, error) {
 	var cfgs [][]byte
 	for _, cfg := range configs {
 		data, err := yaml.Marshal(cfg)
@@ -96,16 +82,4 @@ func MarshalConfigsYaml(configs ...interface{}) ([]byte, error) {
 func YamlMatcher(path string) bool {
 	ext := strings.ToLower(filepath.Ext(path))
 	return ext == ".yaml" || ext == ".yml"
-}
-
-func MarshalConfigsToYaml(in ...interface{}) ([]byte, error) {
-	var configs [][]byte
-	for i := range in {
-		config, err := yaml.Marshal(in[i])
-		if err != nil {
-			return nil, err
-		}
-		configs = append(configs, config)
-	}
-	return bytes.Join(configs, []byte("\n---\n")), nil
 }


### PR DESCRIPTION
- unmount rootfs is executed when the sealer delete -m command deletes some nodes.
- delete duplicate function.
- desired Clusterfile is saved before the runtime during cluster create or scale up.