### PR TITLE
build arg instruction support newline list input

### DIFF
--- a/build/buildkit/buildimage/build_image.go
+++ b/build/buildkit/buildimage/build_image.go
@@ -188,12 +188,13 @@ func (b BuildImage) collectLayers() error {
 	if err != nil {
 		return fmt.Errorf("failed to register layer, err: %v", err)
 	}
-	if layer.ID == "" {
+
+	if layer.ID != "" {
+		b.NewLayers = append(b.NewLayers, layer)
+	} else {
 		logger.Warn("no rootfs diff content found")
-		return nil
 	}
 
-	b.NewLayers = append(b.NewLayers, layer)
 	b.RawImage.Spec.Layers = append(b.BaseLayers, b.NewLayers...)
 	return nil
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -140,17 +140,21 @@ func dispatchArg(layerValue string, ima *v1.Image) {
 	if ima.Spec.ImageConfig.Args == nil {
 		ima.Spec.ImageConfig.Args = map[string]string{}
 	}
-	valueLine := strings.SplitN(layerValue, "=", 2)
-	if len(valueLine) != 2 {
-		logger.Error("invalid ARG value %s. ARG format must be key=value", layerValue)
-		return
+
+	kv := strings.Split(layerValue, ",")
+	for _, element := range kv {
+		valueLine := strings.SplitN(element, "=", 2)
+		if len(valueLine) != 2 {
+			logger.Error("invalid ARG value %s. ARG format must be key=value", layerValue)
+			return
+		}
+		k := strings.TrimSpace(valueLine[0])
+		if !utils.IsLetterOrNumber(k) {
+			logger.Error("ARG key must be letter or number,invalid ARG format will ignore this key %s.", k)
+			return
+		}
+		ima.Spec.ImageConfig.Args[k] = strings.TrimSpace(valueLine[1])
 	}
-	k := strings.TrimSpace(valueLine[0])
-	if !utils.IsLetterOrNumber(k) {
-		logger.Error("ARG key must be letter or number,invalid ARG format will ignore this key %s.", k)
-		return
-	}
-	ima.Spec.ImageConfig.Args[k] = strings.TrimSpace(valueLine[1])
 }
 
 func dispatchDefault(layerType, layerValue string, ima *v1.Image) {

--- a/utils/env.go
+++ b/utils/env.go
@@ -36,6 +36,9 @@ func ConvertMapToEnvList(m map[string]string) []string {
 
 func IsLetterOrNumber(k string) bool {
 	for _, r := range k {
+		if r == '_' {
+			continue
+		}
 		if !unicode.IsLetter(r) && !unicode.IsNumber(r) {
 			return false
 		}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

below is my test kubefile: 
```
FROM kubernetes:v1.19.8
ARG value=sealer
ARG MY_ARG=abc
ARG MY_*ARG=abc # not support such key format.will ignoring this key.
ARG ddd= # default value is "".
ARG name=testname \
,PASSWORD1=PASSWORD1,\
aptget=update 
COPY aa .
COPY charts charts
RUN echo ${name}
RUN echo ${MY_ARG}
CMD echo ${PASSWORD1}
```

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
