### PR TITLE
set cmd arg for sealer run 

### DIFF
--- a/apply/run.go
+++ b/apply/run.go
@@ -82,6 +82,7 @@ func (c *ClusterArgs) SetClusterArgs() error {
 	c.cluster.Spec.SSH.PkPasswd = c.runArgs.PkPassword
 	c.cluster.Spec.SSH.Port = c.runArgs.Port
 	c.cluster.Spec.Env = append(c.cluster.Spec.Env, c.runArgs.CustomEnv...)
+	c.cluster.Spec.CMDArgs = append(c.cluster.Spec.CMDArgs, c.runArgs.CMDArgs...)
 	if c.runArgs.Password != "" {
 		c.cluster.Spec.SSH.Passwd = c.runArgs.Password
 	}

--- a/common/structs.go
+++ b/common/structs.go
@@ -26,4 +26,5 @@ type RunArgs struct {
 	SvcCidr    string
 	Provider   string
 	CustomEnv  []string
+	CMDArgs    []string
 }

--- a/pkg/guest/guest.go
+++ b/pkg/guest/guest.go
@@ -59,14 +59,14 @@ func (d *Default) Apply(cluster *v2.Cluster) error {
 	clusterRootfs := common.DefaultTheClusterRootfsDir(cluster.Name)
 
 	ex := shell.NewLex('\\')
-	var buildArgs []string
+	var args []string
 	if image.Spec.ImageConfig.Args != nil {
-		buildArgs = append(buildArgs, utils.ConvertMapToEnvList(image.Spec.ImageConfig.Args)...)
+		args = append(args, utils.ConvertMapToEnvList(image.Spec.ImageConfig.Args)...)
 	}
-	if len(cluster.Spec.Env) != 0 {
-		buildArgs = append(buildArgs, cluster.Spec.Env...)
+	if len(cluster.Spec.CMDArgs) != 0 {
+		args = append(args, cluster.Spec.CMDArgs...)
 	}
-	arg := utils.ConvertEnvListToMap(buildArgs)
+	arg := utils.ConvertEnvListToMap(args)
 	for i := range image.Spec.Layers {
 		if image.Spec.Layers[i].Type != common.CMDCOMMAND {
 			continue

--- a/sealer/cmd/build.go
+++ b/sealer/cmd/build.go
@@ -39,7 +39,7 @@ var buildConfig *BuildFlag
 // buildCmd represents the build command
 var buildCmd = &cobra.Command{
 	Use:   "build [flags] PATH",
-	Short: "cloud image local build command line",
+	Short: "Build an cloud image from a Kubefile",
 	Long:  "sealer build -f Kubefile -t my-kubernetes:1.19.9 [--mode cloud|container|lite] [--no-cache]",
 	Args:  cobra.ExactArgs(1),
 	Example: `the current path is the context path, default build type is lite and use build cache
@@ -88,7 +88,7 @@ func init() {
 	buildCmd.Flags().StringVarP(&buildConfig.ImageName, "imageName", "t", "", "cluster image name")
 	buildCmd.Flags().BoolVar(&buildConfig.NoCache, "no-cache", false, "build without cache")
 	buildCmd.Flags().BoolVar(&buildConfig.Base, "base", true, "build with base image,default value is true.")
-	buildCmd.Flags().StringSliceVar(&buildConfig.BuildArgs, "build-arg", []string{}, "set custom build arg variables")
+	buildCmd.Flags().StringSliceVar(&buildConfig.BuildArgs, "build-arg", []string{}, "set custom build args")
 
 	if err := buildCmd.MarkFlagRequired("imageName"); err != nil {
 		logger.Error("failed to init flag: %v", err)

--- a/sealer/cmd/run.go
+++ b/sealer/cmd/run.go
@@ -75,7 +75,8 @@ func init() {
 	runCmd.Flags().StringVarP(&runArgs.Password, "passwd", "p", "", "set cloud provider or baremetal server password")
 	runCmd.Flags().StringVar(&runArgs.Port, "port", ssh.DefaultSSHPort, "set the sshd service port number for the server (default port: 22)")
 	runCmd.Flags().StringVar(&runArgs.Pk, "pk", cert.GetUserHomeDir()+"/.ssh/id_rsa", "set baremetal server private key")
-	runCmd.Flags().StringVar(&runArgs.PkPassword, "pk-passwd", "", "set baremetal server  private key password")
+	runCmd.Flags().StringVar(&runArgs.PkPassword, "pk-passwd", "", "set baremetal server private key password")
+	runCmd.Flags().StringSliceVar(&runArgs.CMDArgs, "cmd-args", []string{}, "set args for image cmd instruction")
 	runCmd.Flags().StringSliceVarP(&runArgs.CustomEnv, "env", "e", []string{}, "set custom environment variables")
 	err := runCmd.RegisterFlagCompletionFunc("provider", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return utils.ContainList([]string{common.BAREMETAL, common.AliCloud, common.CONTAINER}, toComplete), cobra.ShellCompDirectiveNoFileComp

--- a/types/api/v2/cluster_types.go
+++ b/types/api/v2/cluster_types.go
@@ -34,9 +34,10 @@ type ClusterSpec struct {
 	// Why env not using map[string]string
 	// Because some argument is list, like: CertSANS=127.0.0.1 CertSANS=localhost, if ENV is map, will merge those two values
 	// but user want to config a list, using array we can convert it to {CertSANS:[127.0.0.1, localhost]}
-	Env   []string `json:"env,omitempty"`
-	Hosts []Host   `json:"hosts,omitempty"`
-	SSH   v1.SSH   `json:"ssh,omitempty"`
+	Env     []string `json:"env,omitempty"`
+	CMDArgs []string `json:"cmd_args,omitempty"`
+	Hosts   []Host   `json:"hosts,omitempty"`
+	SSH     v1.SSH   `json:"ssh,omitempty"`
 }
 
 type Host struct {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

kubefile:
```shell
FROM kubernetes:v1.19.8
ARG Version=4.0.0 # set default version is 4.0.0, this will be used to install mongo application.
COPY mongo manifests # mongo dir contains many mongo version yaml file.
CMD kubectl apply -f mongo-${Version}.yaml # use Version arg to install mongo application.
```

overwrite args of CMD instruction from kubefile at run stage.

examples:
use this arg directly via cmdline :
`
 sealer run --cmd-args Version=5.1.1  -m 172.16.0.227 -p passsword my-mongo:v1
`

use it via clusterfile:

```yaml
apiVersion: sealer.cloud/v2
kind: Cluster
metadata:
  creationTimestamp: null
  name: my-cluster
spec:
  cmd_args:
  - Version=4.9.0
  hosts:
  - ips:
    - 172.16.0.227
  image:  my-mongo:v1
  ssh:
    passwd: passsword
    pk: /root/.ssh/id_rsa
    port: "22"
    user: root
```


priority order：
sealer run cmd >clusterfile>sealer build cmd >kubefile

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
