### PR TITLE
feat:build support save output as tar file

### DIFF
--- a/build/buildkit/buildimage/image_interface.go
+++ b/build/buildkit/buildimage/image_interface.go
@@ -16,12 +16,13 @@ package buildimage
 
 import (
 	"github.com/alibaba/sealer/build/buildkit/buildinstruction"
+	"github.com/alibaba/sealer/build/buildkit/buildstorage"
 	v1 "github.com/alibaba/sealer/types/api/v1"
 )
 
 type Interface interface {
 	ExecBuild(ctx Context) error
-	SaveBuildImage(name string, opts SaveOpts) error
+	SaveBuildImage(name string, saver buildstorage.ImageSaver, opts SaveOpts) error
 	Cleanup() error
 }
 

--- a/build/buildkit/buildstorage/filesystem.go
+++ b/build/buildkit/buildstorage/filesystem.go
@@ -1,0 +1,56 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildstorage
+
+import (
+	"github.com/alibaba/sealer/pkg/image/store"
+	v1 "github.com/alibaba/sealer/types/api/v1"
+)
+
+type filesystem struct {
+	imageStore store.ImageStore
+}
+
+func (f filesystem) Save(image *v1.Image) error {
+	err := f.imageStore.Save(*image, image.Name)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func NewFileSystem() (ImageSaver, error) {
+	imageStore, err := store.NewDefaultImageStore()
+	if err != nil {
+		return nil, err
+	}
+	return filesystem{
+		imageStore: imageStore,
+	}, nil
+}
+
+type filesystemFactory struct{}
+
+func (factory *filesystemFactory) Create(parameters map[string]string) (ImageSaver, error) {
+	is, err := NewFileSystem()
+	if err != nil {
+		return nil, err
+	}
+	return is, nil
+}
+
+func init() {
+	Register(FileSystemFactory, &filesystemFactory{})
+}

--- a/build/buildkit/buildstorage/localfile.go
+++ b/build/buildkit/buildstorage/localfile.go
@@ -1,0 +1,72 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildstorage
+
+import (
+	"github.com/alibaba/sealer/pkg/image"
+	"github.com/alibaba/sealer/pkg/image/store"
+	v1 "github.com/alibaba/sealer/types/api/v1"
+)
+
+type localFile struct {
+	saveName    string
+	imageStore  store.ImageStore
+	fileService image.FileService
+}
+
+func (l localFile) Save(image *v1.Image) error {
+	err := l.imageStore.Save(*image, image.Name)
+	if err != nil {
+		return err
+	}
+
+	err = l.fileService.Save(image, l.saveName)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func NewLocalFile(saveName string) (ImageSaver, error) {
+	fs, err := image.NewImageFileService()
+	if err != nil {
+		return nil, err
+	}
+
+	is, err := store.NewDefaultImageStore()
+	if err != nil {
+		return nil, err
+	}
+
+	return localFile{
+		saveName:    saveName,
+		fileService: fs,
+		imageStore:  is,
+	}, nil
+}
+
+type localFileFactory struct{}
+
+func (factory *localFileFactory) Create(parameters map[string]string) (ImageSaver, error) {
+	is, err := NewLocalFile(parameters["dest"])
+	if err != nil {
+		return nil, err
+	}
+	return is, nil
+}
+
+func init() {
+	Register(LocalFileFactory, &localFileFactory{})
+}

--- a/build/buildkit/buildstorage/stoage_interface.go
+++ b/build/buildkit/buildstorage/stoage_interface.go
@@ -33,7 +33,7 @@ type StorageDriver struct {
 }
 
 type ImageSaver interface {
-	// Save :save image as local registry,local file,or oss file store.default is local registry.
+	// Save :save image at filesystem,local file,or oss file store.default is filesystem.
 	Save(image *v1.Image) error
 }
 

--- a/build/config.go
+++ b/build/config.go
@@ -16,6 +16,7 @@ package build
 
 type Config struct {
 	BuildType string
+	Output    string
 	NoCache   bool
 	NoBase    bool
 	ImageName string

--- a/pkg/image/default_image_file.go
+++ b/pkg/image/default_image_file.go
@@ -47,36 +47,40 @@ func (d DefaultImageFileService) Load(imageSrc string) error {
 	return err
 }
 
-func (d DefaultImageFileService) Save(imageName string, imageTar string) error {
+func (d DefaultImageFileService) Save(image *v1.Image, imageTar string) error {
+	// imageTar maybe below value:
+	// full name : /tmp/image.tar
+	// only file name : image.tar
+	// only file path: /tmp , /tmp/
 	if imageTar == "" {
 		return fmt.Errorf("imagetar cannot be empty")
 	}
 
-	if utils.IsFileExist(imageTar) {
-		return fmt.Errorf("file %s already exists", imageTar)
+	dir, file := filepath.Split(imageTar)
+	if dir == "" {
+		dir = "."
+	}
+	if file == "" {
+		file = fmt.Sprintf("%s.tar", image.Name)
+	}
+	imageTar = filepath.Join(dir, file)
+	// only file path like "/tmp" will lose add image tar name,make sure imageTar with full file name.
+	if filepath.Ext(imageTar) != ".tar" {
+		imageTar = filepath.Join(imageTar, fmt.Sprintf("%s.tar", image.Name))
 	}
 
 	if err := utils.MkFileFullPathDir(imageTar); err != nil {
 		return fmt.Errorf("failed to create %s, err: %v", imageTar, err)
 	}
 
-	return d.save(imageName, imageTar)
+	return d.save(image, imageTar)
 }
 
 func (d DefaultImageFileService) Merge(image *v1.Image) error {
 	panic("implement me")
 }
 
-func (d DefaultImageFileService) save(imageName, imageTar string) error {
-	named, err := reference.ParseToNamed(imageName)
-	if err != nil {
-		return err
-	}
-
-	image, err := d.imageStore.GetByName(named.Raw())
-	if err != nil {
-		return err
-	}
+func (d DefaultImageFileService) save(image *v1.Image, imageTar string) error {
 	file, err := os.Create(filepath.Clean(imageTar))
 	if err != nil {
 		return fmt.Errorf("failed to create %s, err: %v", imageTar, err)
@@ -108,7 +112,7 @@ func (d DefaultImageFileService) save(imageName, imageTar string) error {
 	if err = utils.AtomicWriteFile(imageMetadataTempFile, imgBytes, common.FileMode0644); err != nil {
 		return fmt.Errorf("failed to write temp file %s, err: %v ", imageMetadataTempFile, err)
 	}
-	metadata, err := d.imageStore.GetImageMetadataItem(named.Raw())
+	metadata, err := d.imageStore.GetImageMetadataItem(image.Name)
 	if err != nil {
 		return err
 	}
@@ -123,7 +127,7 @@ func (d DefaultImageFileService) save(imageName, imageTar string) error {
 	pathsToCompress = append(pathsToCompress, imageMetadataTempFile, repofile)
 	tarReader, err := archive.TarWithRootDir(pathsToCompress...)
 	if err != nil {
-		return fmt.Errorf("failed to get tar reader for %s, err: %s", named.Raw(), err)
+		return fmt.Errorf("failed to get tar reader for %s, err: %s", image.Name, err)
 	}
 	defer tarReader.Close()
 

--- a/pkg/image/image_interface.go
+++ b/pkg/image/image_interface.go
@@ -32,7 +32,7 @@ type MetadataService interface {
 // FileService is the interface for file operations
 type FileService interface {
 	Load(imageSrc string) error
-	Save(imageName string, imageTar string) error
+	Save(image *v1.Image, imageTar string) error
 	Merge(image *v1.Image) error
 }
 

--- a/sealer/cmd/build.go
+++ b/sealer/cmd/build.go
@@ -41,29 +41,29 @@ var buildConfig *BuildFlag
 var buildCmd = &cobra.Command{
 	Use:   "build [flags] PATH",
 	Short: "Build an cloud image from a Kubefile",
-	Long:  "sealer build -f Kubefile -t my-kubernetes:1.19.9 [--mode cloud|container|lite] [--no-cache]",
+	Long:  "sealer build -f Kubefile -t my-kubernetes:1.19.8 [--mode cloud|container|lite] [--no-cache]",
 	Example: `the current path is the context path, default build type is lite and use build cache
 
 lite build:
-	sealer build -f Kubefile -t my-kubernetes:1.19.9 .
+	sealer build -f Kubefile -t my-kubernetes:1.19.8 .
 
 container build:
-	sealer build -f Kubefile -t my-kubernetes:1.19.9 -m container .
+	sealer build -f Kubefile -t my-kubernetes:1.19.8 -m container .
 
 cloud build:
-	sealer build -f Kubefile -t my-kubernetes:1.19.9 --mode cloud .
+	sealer build -f Kubefile -t my-kubernetes:1.19.8 --mode cloud .
 
 build without cache:
-	sealer build -f Kubefile -t my-kubernetes:1.19.9 --no-cache .
+	sealer build -f Kubefile -t my-kubernetes:1.19.8 --no-cache .
 
 build without base:
-	sealer build -f Kubefile -t my-kubernetes:1.19.9 --base=false .
+	sealer build -f Kubefile -t my-kubernetes:1.19.8 --base=false .
 
 build with args:
-	sealer build -f Kubefile -t my-kubernetes:1.19.9 --build-arg MY_ARG=abc,PASSWORD=Sealer123 .
+	sealer build -f Kubefile -t my-kubernetes:1.19.8 --build-arg MY_ARG=abc,PASSWORD=Sealer123 .
 
-build with different save:
-	sealer build -f Kubefile -t my-kubernetes:1.19.9 --output type=local,dest=/path/to/my-image.tar .
+build with specific output:
+	sealer build -f Kubefile -t my-kubernetes:1.19.8 --output type=local,dest=/path/to/my-image.tar .
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		conf := &build.Config{

--- a/sealer/cmd/save.go
+++ b/sealer/cmd/save.go
@@ -18,6 +18,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/alibaba/sealer/pkg/image/reference"
+	"github.com/alibaba/sealer/pkg/image/store"
+
 	"github.com/spf13/cobra"
 
 	"github.com/alibaba/sealer/logger"
@@ -41,7 +44,20 @@ sealer save -o kubernetes.tar kubernetes:v1.19.8`,
 		if err != nil {
 			return err
 		}
-		if err = ifs.Save(args[0], ImageTar); err != nil {
+		named, err := reference.ParseToNamed(args[0])
+		if err != nil {
+			return err
+		}
+		imageStore, err := store.NewDefaultImageStore()
+		if err != nil {
+			return err
+		}
+		image, err := imageStore.GetByName(named.Raw())
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%+v\n", image)
+		if err = ifs.Save(image, ImageTar); err != nil {
 			return fmt.Errorf("failed to save image %s: %v", args[0], err)
 		}
 		logger.Info("save image %s to %s successfully", args[0], ImageTar)

--- a/sealer/cmd/save.go
+++ b/sealer/cmd/save.go
@@ -56,7 +56,7 @@ sealer save -o kubernetes.tar kubernetes:v1.19.8`,
 		if err != nil {
 			return err
 		}
-		fmt.Printf("%+v\n", image)
+
 		if err = ifs.Save(image, ImageTar); err != nil {
 			return fmt.Errorf("failed to save image %s: %v", args[0], err)
 		}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

build default output is filesystem, if user specify "type=local,dest=dir or filename" ,will save output as local file.

save output at filesystem:

`sealer build -t my-kubernetes:1.19.8`

save output as local file:

`sealer build -t my-kubernetes:1.19.8 --output type=local,dest=/path/to/my-image.tar`

at meantime , `sealer save` support specify dir with default image name as tar filename.

`sealer save kubernetes:v1.19.8 -o /tmp `


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
