### PR TITLE
fix: add index=off option for overlay2 mount

### DIFF
--- a/build/buildkit/buildinstruction/mount.go
+++ b/build/buildkit/buildinstruction/mount.go
@@ -41,7 +41,7 @@ func (m MountTarget) TempMount() error {
 func (m MountTarget) TempUMount() error {
 	err := m.driver.Unmount(m.TempTarget)
 	if err != nil {
-		return fmt.Errorf("failed to mount target %s:%v", m.TempTarget, err)
+		return fmt.Errorf("failed to umount target %s:%v", m.TempTarget, err)
 	}
 	return nil
 }


### PR DESCRIPTION


<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Background :

some linux kernel  dont support overlay2 default option index=on. that is if "/sys/module/overlay/parameters/index" is "Y"
,will cause the mount to fail。

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
