### PR TITLE
nydus: get localIP and set nydusd host config Automatically

### DIFF
--- a/applications/nydus/nydusdfile/serverstart.sh
+++ b/applications/nydus/nydusdfile/serverstart.sh
@@ -3,6 +3,36 @@
 #nydusdir need be scp
 rm -rf $2
 mkdir $2
+nydusdconfig='
+{\n
+  "device": {\n
+    "backend": {\n
+      "type": "registry",\n
+      "config": {\n
+        "scheme": "http",\n
+        "host": "'${3}':8000",\n
+        "repo": "sealer"\n
+      }\n
+    },\n
+    "cache": {\n
+      "type": "blobcache",\n
+      "config": {\n
+        "work_dir": "./cache"\n
+      }\n
+    }\n
+  },\n
+  "mode": "direct",\n
+  "digest_validate": false,\n
+  "enable_xattr": true,\n
+  "fs_prefetch": {\n
+    "enable": true,\n
+    "threads_count": 1,\n
+    "merging_size": 131072,\n
+    "bandwidth_rate":10485760\n
+  }\n
+}\n
+'
+echo -e ${nydusdconfig} > ./nydusd_scp_file/httpserver.json
 cp ./nydusd_scp_file/* $2
 cp ./rootfs.meta $2
 # nydusd_http_server.service

--- a/utils/iputils.go
+++ b/utils/iputils.go
@@ -79,6 +79,15 @@ func IsLocalIP(ip string, addrs *[]net.Addr) bool {
 	return false
 }
 
+func GetLocalIP(master0IP string) (string, error) {
+	conn, err := net.Dial("udp", master0IP)
+	if err != nil {
+		return "", err
+	}
+	localAddr := conn.LocalAddr().String()
+	return strings.Split(localAddr, ":")[0], err
+}
+
 func AssemblyIPList(args *string) error {
 	var result []string
 	var ips = strings.Split(*args, "-")


### PR DESCRIPTION
Signed-off-by: lihongnan <hongnan.lhn@alibaba-inc.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Get localIP and set nydusd host config Automatically.
Nydusd need to set the IP of nydusdserver as host config in httpserver.json, and it is unfriendly to modify the nydusd configs manually.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it

