### PR TITLE
Feat: taint plugin

### DIFF
--- a/pkg/plugin/cluster_check_plugin.go
+++ b/pkg/plugin/cluster_check_plugin.go
@@ -34,7 +34,7 @@ func NewClusterCheckerPlugin() Interface {
 }
 
 func init() {
-	Register(ClusterCheckPlugin, &ClusterChecker{})
+	Register(ClusterCheckPlugin, NewClusterCheckerPlugin())
 }
 
 func (c *ClusterChecker) Run(context Context, phase Phase) error {

--- a/pkg/plugin/etcd_backup_plugin.go
+++ b/pkg/plugin/etcd_backup_plugin.go
@@ -39,7 +39,7 @@ func NewEtcdBackupPlugin() Interface {
 }
 
 func init() {
-	Register(EtcdPlugin, &EtcdBackupPlugin{})
+	Register(EtcdPlugin, NewEtcdBackupPlugin())
 }
 
 func (e EtcdBackupPlugin) Run(context Context, phase Phase) error {

--- a/pkg/plugin/hostname_plugin.go
+++ b/pkg/plugin/hostname_plugin.go
@@ -31,7 +31,7 @@ func NewHostnamePlugin() Interface {
 }
 
 func init() {
-	Register(HostNamePlugin, &HostnamePlugin{})
+	Register(HostNamePlugin, NewHostnamePlugin())
 }
 
 func (h HostnamePlugin) Run(context Context, phase Phase) error {

--- a/pkg/plugin/labels.go
+++ b/pkg/plugin/labels.go
@@ -39,7 +39,7 @@ func NewLabelsPlugin() Interface {
 }
 
 func init() {
-	Register(LabelPlugin, &LabelsNodes{})
+	Register(LabelPlugin, NewLabelsPlugin())
 }
 
 func (l LabelsNodes) Run(context Context, phase Phase) error {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -41,6 +41,7 @@ const (
 	EtcdPlugin         = "ETCD"
 	LabelPlugin        = "LABEL"
 	ShellPlugin        = "SHELL"
+	TaintPlugin        = "Taint"
 	HostNamePlugin     = "HOSTNAME"
 	ClusterCheckPlugin = "CLUSTERCHECK"
 )

--- a/pkg/plugin/shell_plugin.go
+++ b/pkg/plugin/shell_plugin.go
@@ -34,6 +34,10 @@ func NewShellPlugin() Interface {
 	return &Sheller{}
 }
 
+func init() {
+	Register(ShellPlugin, NewShellPlugin())
+}
+
 func (s Sheller) Run(context Context, phase Phase) error {
 	if string(phase) != context.Plugin.Spec.Action || context.Plugin.Spec.Type != ShellPlugin {
 		return nil
@@ -83,8 +87,4 @@ func (s Sheller) Run(context Context, phase Phase) error {
 		}
 	}
 	return nil
-}
-
-func init() {
-	Register(ShellPlugin, &Sheller{})
 }

--- a/pkg/plugin/shell_plugin.go
+++ b/pkg/plugin/shell_plugin.go
@@ -16,13 +16,8 @@ package plugin
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/alibaba/sealer/pkg/env"
-
-	"github.com/alibaba/sealer/utils"
-
-	"github.com/alibaba/sealer/pkg/client/k8s"
 
 	"github.com/alibaba/sealer/common"
 	"github.com/alibaba/sealer/utils/ssh"
@@ -38,7 +33,7 @@ func init() {
 	Register(ShellPlugin, NewShellPlugin())
 }
 
-func (s Sheller) Run(context Context, phase Phase) error {
+func (s Sheller) Run(context Context, phase Phase) (err error) {
 	if string(phase) != context.Plugin.Spec.Action || context.Plugin.Spec.Type != ShellPlugin {
 		return nil
 	}
@@ -50,29 +45,9 @@ func (s Sheller) Run(context Context, phase Phase) error {
 	//get all host ip
 	allHostIP := append(context.Cluster.GetMasterIPList(), context.Cluster.GetNodeIPList()...)
 	if on := context.Plugin.Spec.On; on != "" {
-		if strings.Contains(on, "=") {
-			if phase != PhasePostInstall {
-				return fmt.Errorf("the action must be PostInstall, When nodes is specified with a label")
-			}
-			client, err := k8s.Newk8sClient()
-			if err != nil {
-				return err
-			}
-			ipList, err := client.ListNodeIPByLabel(strings.TrimSpace(on))
-			if err != nil {
-				return err
-			}
-			if len(ipList) == 0 {
-				return fmt.Errorf("nodes is not found by label [%s]", on)
-			}
-			allHostIP = ipList
-		} else if on == common.MASTER || on == common.NODE {
-			allHostIP = context.Cluster.GetIPSByRole(on)
-			if allHostIP == nil {
-				return fmt.Errorf("role is not found [%s]", on)
-			}
-		} else {
-			allHostIP = utils.DisassembleIPList(on)
+		allHostIP, err = GetIpsByOnField(on, context, phase)
+		if err != nil {
+			return err
 		}
 	}
 	for _, ip := range allHostIP {

--- a/pkg/plugin/taint_plugin.go
+++ b/pkg/plugin/taint_plugin.go
@@ -28,13 +28,20 @@ import (
 
 var TaintEffectValues = []v1.TaintEffect{v1.TaintEffectNoSchedule, v1.TaintEffectNoExecute, v1.TaintEffectPreferNoSchedule}
 
+type TaintList map[string]*taintList //map[ip]taint
+
 type Taint struct {
+	IPList []string
+	TaintList
+}
+
+type taintList struct {
 	DelTaintList []v1.Taint
 	AddTaintList []v1.Taint
 }
 
 func NewTaintPlugin() Interface {
-	return &Taint{}
+	return &Taint{TaintList: map[string]*taintList{}}
 }
 
 func init() {
@@ -53,24 +60,11 @@ func newTaintStruct(key, value, effect string) v1.Taint {
 //spec:
 //  type: Taint
 //  action: PreGuest
-//  'on': master ##"'on': 192.168.56.1,192.168.56.2,192.168.56.3" or "'on': 192.168.56.1-192.168.56.3
-//  data: key1=value1:NoSchedule ## add taint
-//  #data: key1=value1:NoSchedule- ## del taint
+//  data: 192.168.56.3 key1=value1:NoSchedule ## add taint
+//  #data: 192.168.56.3 key1=value1:NoSchedule- ## del taint
 
 func (l *Taint) Run(context Context, phase Phase) (err error) {
 	if phase != PhasePreGuest || context.Plugin.Spec.Type != TaintPlugin {
-		logger.Debug("label nodes is PostInstall!")
-		return nil
-	}
-	allHostIP := append(context.Cluster.GetMasterIPList(), context.Cluster.GetNodeIPList()...)
-	if on := context.Plugin.Spec.On; on != "" {
-		allHostIP, err = GetIpsByOnField(on, context, phase)
-		if err != nil {
-			return err
-		}
-	}
-	if len(allHostIP) == 0 {
-		logger.Info("not found ip list with cluster role %s", context.Plugin.Spec.On)
 		return nil
 	}
 
@@ -91,10 +85,10 @@ func (l *Taint) Run(context Context, phase Phase) (err error) {
 	for _, n := range nodeList.Items {
 		node := n
 		for _, v := range node.Status.Addresses {
-			if !utils.InList(v.Address, allHostIP) {
+			if !utils.InList(v.Address, l.IPList) {
 				continue
 			}
-			updateTaints := l.UpdateTaints(node.Spec.Taints)
+			updateTaints := l.UpdateTaints(node.Spec.Taints, v.Address)
 			if updateTaints != nil {
 				node.Spec.Taints = updateTaints
 				_, err := k8sClient.UpdateNode(node)
@@ -114,68 +108,82 @@ func (l *Taint) formatData(data string) error {
 	items := strings.Split(data, "\n")
 	for _, v := range items {
 		v = strings.TrimSpace(v)
-		if strings.HasSuffix(v, "#") || v == "" {
+		if strings.HasPrefix(v, "#") || v == "" {
 			continue
 		}
-		isDelTaint := false
-		if strings.HasSuffix(v, DelSymbol) {
-			isDelTaint = true
+		temps := strings.Split(v, " ")
+		if len(temps) != 2 {
+			return fmt.Errorf("faild to split taint argument: %s", v)
 		}
-		taintArgs := strings.Split(v, ColonSymbol)
-		if len(taintArgs) != 2 && isDelTaint {
+		ips := temps[0]
+		err := utils.AssemblyIPList(&ips)
+		if err != nil {
+			return err
+		}
+		l.IPList = append(l.IPList, ips)
+		//kubectl taint nodes xxx key- : remove all key related taints
+		if strings.HasSuffix(temps[1], DelSymbol) && !strings.Contains(temps[1], ColonSymbol) && !strings.Contains(temps[1], EqualSymbol) {
+			l.TaintList[ips].DelTaintList = append(l.TaintList[ips].DelTaintList, newTaintStruct(strings.TrimSuffix(temps[1], DelSymbol), "", ""))
+			continue
+		}
+		taintArgs := strings.Split(temps[1], ColonSymbol)
+		if len(taintArgs) != 2 {
 			return fmt.Errorf("error: invalid taint data: %s", v)
 		}
 		kv, effect := taintArgs[0], taintArgs[1]
 		effect = strings.TrimSuffix(effect, DelSymbol)
-		if NotInEffect(v1.TaintEffect(effect), TaintEffectValues) && effect != "" {
+		if NotInEffect(v1.TaintEffect(effect), TaintEffectValues) {
 			return fmt.Errorf("taint effect %s need in %v", v, TaintEffectValues)
 		}
 		kvList := strings.Split(kv, EqualSymbol)
 		key, value := kvList[0], ""
 		if len(kvList) > 2 || key == "" {
-			return fmt.Errorf("error: invalid taint data: %s", v)
+			return fmt.Errorf("error: invalid taint data: %s", temps[1])
 		}
 		if len(kvList) == 2 {
 			value = kvList[1]
 		}
 		taint := newTaintStruct(key, value, effect)
-		if isDelTaint {
-			l.DelTaintList = append(l.DelTaintList, taint)
+		if _, ok := l.TaintList[ips]; !ok {
+			l.TaintList[ips] = &taintList{}
+		}
+		if strings.HasSuffix(temps[1], DelSymbol) {
+			l.TaintList[ips].DelTaintList = append(l.TaintList[ips].DelTaintList, taint)
 			continue
 		}
-		l.AddTaintList = append(l.AddTaintList, taint)
+		l.TaintList[ips].AddTaintList = append(l.TaintList[ips].AddTaintList, taint)
 	}
 	return nil
 }
 
 // UpdateTaints return nil mean's needn't update taint
-func (l *Taint) UpdateTaints(taints []v1.Taint) []v1.Taint {
-	needUpdate := false
+func (l *Taint) UpdateTaints(taints []v1.Taint, ip string) []v1.Taint {
+	needDel := false
 	for k, v := range taints {
-		l.removePresenceTaint(v)
-		if l.isDelTaint(v) {
-			needUpdate = true
+		l.removePresenceTaint(v, ip)
+		if l.isDelTaint(v, ip) {
+			needDel = true
 			taints = append(taints[:k], taints[k+1:]...)
 		}
 	}
-	if len(l.AddTaintList) == 0 && needUpdate {
+	if len(l.TaintList[ip].AddTaintList) == 0 && !needDel {
 		return nil
 	}
-	return append(taints, l.AddTaintList...)
+	return append(taints, l.TaintList[ip].AddTaintList...)
 }
 
 //Remove existing taint
-func (l *Taint) removePresenceTaint(taint v1.Taint) {
-	for k, v := range l.AddTaintList {
+func (l *Taint) removePresenceTaint(taint v1.Taint, ip string) {
+	for k, v := range l.TaintList[ip].AddTaintList {
 		if v.Key == taint.Key && v.Value == taint.Value && v.Effect == taint.Effect {
-			logger.Info("taint %s already exist", l.AddTaintList[k].String())
-			l.AddTaintList = append(l.AddTaintList[:k], l.AddTaintList[k+1:]...)
+			logger.Info("taint %s already exist", l.TaintList[ip].AddTaintList[k].String())
+			l.TaintList[ip].AddTaintList = append(l.TaintList[ip].AddTaintList[:k], l.TaintList[ip].AddTaintList[k+1:]...)
 		}
 	}
 }
 
-func (l *Taint) isDelTaint(taint v1.Taint) bool {
-	for _, v := range l.DelTaintList {
+func (l *Taint) isDelTaint(taint v1.Taint, ip string) bool {
+	for _, v := range l.TaintList[ip].AddTaintList {
 		if v.Key == taint.Key && (v.Effect == taint.Effect || v.Effect == "") {
 			return true
 		}

--- a/pkg/plugin/taint_plugin.go
+++ b/pkg/plugin/taint_plugin.go
@@ -1,0 +1,217 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alibaba/sealer/common"
+	"github.com/alibaba/sealer/utils"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/alibaba/sealer/logger"
+	"github.com/alibaba/sealer/pkg/client/k8s"
+)
+
+const (
+	DelSymbol   = "-"
+	EqualSymbol = "="
+	ColonSymbol = ":"
+)
+
+var TaintEffectValues = []v1.TaintEffect{v1.TaintEffectNoSchedule, v1.TaintEffectNoExecute, v1.TaintEffectPreferNoSchedule}
+
+type Taint struct {
+	DelTaintList []v1.Taint
+	AddTaintList []v1.Taint
+}
+
+func NewTaintPlugin() Interface {
+	return &Taint{}
+}
+
+func init() {
+	Register(TaintPlugin, NewTaintPlugin())
+}
+
+func newTaintStruct(key, value, effect string) v1.Taint {
+	return v1.Taint{Key: key, Value: value, Effect: v1.TaintEffect(effect)}
+}
+
+//Run taint_plugin file:
+//apiVersion: sealer.aliyun.com/v1alpha1
+//kind: Plugin
+//metadata:
+//  name: taint
+//spec:
+//  type: Taint
+//  action: PreGuest
+//  'on': master ##"'on': 192.168.56.1,192.168.56.2,192.168.56.3" or "'on': 192.168.56.1-192.168.56.3
+//  data: key1=value1:NoSchedule ## add taint
+//  #data: key1=value1:NoSchedule- ## del taint
+
+func (l *Taint) Run(context Context, phase Phase) error {
+	if phase != PhasePreGuest || context.Plugin.Spec.Type != TaintPlugin {
+		logger.Debug("label nodes is PostInstall!")
+		return nil
+	}
+	allHostIP := append(context.Cluster.GetMasterIPList(), context.Cluster.GetNodeIPList()...)
+	if on := context.Plugin.Spec.On; on != "" {
+		if strings.Contains(on, EqualSymbol) {
+			if phase != PhasePostInstall {
+				return fmt.Errorf("the action must be PostInstall, When nodes is specified with a label")
+			}
+			client, err := k8s.Newk8sClient()
+			if err != nil {
+				return err
+			}
+			ipList, err := client.ListNodeIPByLabel(strings.TrimSpace(on))
+			if err != nil {
+				return err
+			}
+			if len(ipList) == 0 {
+				return fmt.Errorf("nodes is not found by label [%s]", on)
+			}
+			allHostIP = ipList
+		} else if on == common.MASTER || on == common.NODE {
+			allHostIP = context.Cluster.GetIPSByRole(on)
+		} else {
+			allHostIP = utils.DisassembleIPList(on)
+		}
+	}
+	if len(allHostIP) == 0 {
+		logger.Info("not found ip list with cluster role %s", context.Plugin.Spec.On)
+		return nil
+	}
+
+	err := l.formatData(context.Plugin.Spec.Data)
+	if err != nil {
+		return fmt.Errorf("failed to format data from %s: %v", context.Plugin.Spec.Data, err)
+	}
+
+	k8sClient, err := k8s.Newk8sClient()
+	if err != nil {
+		return err
+	}
+
+	nodeList, err := k8sClient.ListNodes()
+	if err != nil {
+		return err
+	}
+	for _, n := range nodeList.Items {
+		node := n
+		for _, v := range node.Status.Addresses {
+			if !utils.InList(v.Address, allHostIP) {
+				continue
+			}
+			updateTaints := l.UpdateTaints(node.Spec.Taints)
+			if updateTaints != nil {
+				node.Spec.Taints = updateTaints
+				_, err := k8sClient.UpdateNode(node)
+				if err != nil {
+					return err
+				}
+			}
+			break
+		}
+	}
+
+	return nil
+}
+
+//key1=value1:NoSchedule;key1=value1:NoSchedule-;key1:NoSchedule;key1:NoSchedule-;key1=:NoSchedule-;key1=value1:NoSchedule
+func (l *Taint) formatData(data string) error {
+	items := strings.Split(data, "\n")
+	for _, v := range items {
+		v = strings.TrimSpace(v)
+		if strings.HasSuffix(v, "#") || v == "" {
+			continue
+		}
+		isDelTaint := false
+		if strings.HasSuffix(v, DelSymbol) {
+			isDelTaint = true
+		}
+		taintArgs := strings.Split(v, ColonSymbol)
+		if len(taintArgs) != 2 && isDelTaint {
+			return fmt.Errorf("error: invalid taint data: %s", v)
+		}
+		kv, effect := taintArgs[0], taintArgs[1]
+		effect = strings.TrimSuffix(effect, DelSymbol)
+		if NotInEffect(v1.TaintEffect(effect), TaintEffectValues) && effect != "" {
+			return fmt.Errorf("taint effect %s need in %v", v, TaintEffectValues)
+		}
+		kvList := strings.Split(kv, EqualSymbol)
+		key, value := kvList[0], ""
+		if len(kvList) > 2 || key == "" {
+			return fmt.Errorf("error: invalid taint data: %s", v)
+		}
+		if len(kvList) == 2 {
+			value = kvList[1]
+		}
+		taint := newTaintStruct(key, value, effect)
+		if isDelTaint {
+			l.DelTaintList = append(l.DelTaintList, taint)
+			continue
+		}
+		l.AddTaintList = append(l.AddTaintList, taint)
+	}
+	return nil
+}
+
+// UpdateTaints return nil mean's needn't update taint
+func (l *Taint) UpdateTaints(taints []v1.Taint) []v1.Taint {
+	needUpdate := false
+	for k, v := range taints {
+		l.removePresenceTaint(v)
+		if l.isDelTaint(v) {
+			needUpdate = true
+			taints = append(taints[:k], taints[k+1:]...)
+		}
+	}
+	if len(l.AddTaintList) == 0 && needUpdate {
+		return nil
+	}
+	return append(taints, l.AddTaintList...)
+}
+
+//Remove existing taint
+func (l *Taint) removePresenceTaint(taint v1.Taint) {
+	for k, v := range l.AddTaintList {
+		if v.Key == taint.Key && v.Value == taint.Value && v.Effect == taint.Effect {
+			logger.Info("taint %s already exist", l.AddTaintList[k].String())
+			l.AddTaintList = append(l.AddTaintList[:k], l.AddTaintList[k+1:]...)
+		}
+	}
+}
+
+func (l *Taint) isDelTaint(taint v1.Taint) bool {
+	for _, v := range l.DelTaintList {
+		if v.Key == taint.Key && (v.Effect == taint.Effect || v.Effect == "") {
+			return true
+		}
+	}
+	return false
+}
+
+func NotInEffect(effect v1.TaintEffect, effects []v1.TaintEffect) bool {
+	for _, e := range effects {
+		if e == effect {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/plugin/taint_plugin_test.go
+++ b/pkg/plugin/taint_plugin_test.go
@@ -1,0 +1,78 @@
+package plugin
+
+import (
+	"github.com/alibaba/sealer/logger"
+	v1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func TestTaint_formatData(t *testing.T) {
+	type fields struct {
+		DelTaintList []v1.Taint
+		AddTaintList []v1.Taint
+	}
+	type args struct {
+		data string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			"1",
+			fields{},
+			args{
+				data: "addKey1=addValue1:NoSchedule\ndelKey1=delValue1:NoSchedule-\naddKey2=:NoSchedule\ndelKey2=:NoSchedule-;addKey3:NoSchedule;delKey3:NoSchedule-\n",
+			},
+			false,
+		},
+		{
+			"invalid taint argument",
+			fields{},
+			args{
+				data: "addKey1==addValue1:NoSchedule\n",
+			},
+			true,
+		},
+		{
+			"invalid taint argument",
+			fields{},
+			args{
+				data: "addKey1=add:Value1:NoSchedule\n",
+			},
+			true,
+		},
+		{
+			"no key",
+			fields{},
+			args{
+				data: "=addValue1:NoSchedule\n",
+			},
+			true,
+		},
+		{
+			"no effect",
+			fields{},
+			args{
+				data: "addKey1=addValue1:\n",
+			},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := Taint{
+				DelTaintList: tt.fields.DelTaintList,
+				AddTaintList: tt.fields.AddTaintList,
+			}
+			if err := l.formatData(tt.args.data); (err != nil) != tt.wantErr {
+				t.Errorf("formatData() error = %v, wantErr %v", err, tt.wantErr)
+			} else {
+				logger.Info(l.DelTaintList)
+				logger.Info(l.AddTaintList)
+			}
+		})
+	}
+}

--- a/pkg/plugin/taint_plugin_test.go
+++ b/pkg/plugin/taint_plugin_test.go
@@ -1,9 +1,24 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package plugin
 
 import (
+	"testing"
+
 	"github.com/alibaba/sealer/logger"
 	v1 "k8s.io/api/core/v1"
-	"testing"
 )
 
 func TestTaint_formatData(t *testing.T) {

--- a/pkg/plugin/utils.go
+++ b/pkg/plugin/utils.go
@@ -1,0 +1,55 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alibaba/sealer/common"
+	"github.com/alibaba/sealer/pkg/client/k8s"
+	"github.com/alibaba/sealer/utils"
+)
+
+const (
+	DelSymbol   = "-"
+	EqualSymbol = "="
+	ColonSymbol = ":"
+)
+
+func GetIpsByOnField(on string, context Context, phase Phase) (ipList []string, err error) {
+	on = strings.TrimSpace(on)
+	if strings.Contains(on, EqualSymbol) {
+		if phase != PhasePostInstall {
+			return nil, fmt.Errorf("the action must be PostInstall, When nodes is specified with a label")
+		}
+		client, err := k8s.Newk8sClient()
+		if err != nil {
+			return nil, err
+		}
+		ipList, err = client.ListNodeIPByLabel(strings.TrimSpace(on))
+		if err != nil {
+			return nil, err
+		}
+	} else if on == common.MASTER || on == common.NODE {
+		ipList = context.Cluster.GetIPSByRole(on)
+	} else {
+		ipList = utils.DisassembleIPList(on)
+	}
+	if len(ipList) == 0 {
+		return nil, fmt.Errorf("invalid on filed: [%s]", on)
+	}
+	return ipList, nil
+}


### PR DESCRIPTION
taint plugin:
```yaml
apiVersion: sealer.aliyun.com/v1alpha1
kind: Plugin
metadata:
  name: taint
spec:
  type: Taint
  action: PreGuest
  data: |
    192.168.0.2 key1=value1:NoSchedule
    192.168.0.2,192.168.0.3,192.168.0.4 key2=value2:NoSchedule
    192.168.0.2-192.168.0.4 key3:NoSchedule
    192.168.0.2 key4=:NoSchedule
    192.168.0.2 key5:NoSchedule-
    192.168.0.2 key6=value6:NoSchedule-
    192.168.0.2 key7=:NoSchedule-
```
