### PR TITLE
feat:sealer build support multi-user logic to pull docker images

### DIFF
--- a/build/buildkit/buildimage/build_image.go
+++ b/build/buildkit/buildimage/build_image.go
@@ -130,7 +130,7 @@ func (b BuildImage) checkShadow(buildContext string) error {
 		rootfs  = b.RootfsMountInfo.GetMountTarget()
 		shadows = []Shadow{NewShadowPuller()}
 	)
-
+	logger.Info("start to check the shadow file")
 	eg, _ := errgroup.WithContext(context.Background())
 	for _, shadow := range shadows {
 		s := shadow

--- a/build/buildkit/buildimage/build_image.go
+++ b/build/buildkit/buildimage/build_image.go
@@ -56,6 +56,12 @@ func (b BuildImage) ExecBuild(ctx Context) error {
 		buildArgs  = map[string]string{}
 	)
 
+	// process shadow file
+	err := b.checkShadow(execCtx.BuildContext)
+	if err != nil {
+		return err
+	}
+
 	if b.RawImage.Spec.ImageConfig.Args != nil {
 		for k, v := range b.RawImage.Spec.ImageConfig.Args {
 			buildArgs[k] = v
@@ -119,6 +125,26 @@ func (b BuildImage) ExecBuild(ctx Context) error {
 	return nil
 }
 
+func (b BuildImage) checkShadow(buildContext string) error {
+	var (
+		rootfs  = b.RootfsMountInfo.GetMountTarget()
+		shadows = []Shadow{NewShadowPuller()}
+	)
+
+	eg, _ := errgroup.WithContext(context.Background())
+	for _, shadow := range shadows {
+		s := shadow
+		eg.Go(func() error {
+			err := s.Process(buildContext, rootfs)
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+	}
+	return eg.Wait()
+}
+
 func (b BuildImage) genNewLayer(layerType, layerValue, filepath string) (v1.Layer, error) {
 	imageLayer := v1.Layer{
 		Type:  layerType,
@@ -159,6 +185,7 @@ func (b BuildImage) checkDiff() error {
 
 func (b BuildImage) SaveBuildImage(name string, opts SaveOpts) error {
 	b.RawImage.Name = name
+	// process differ of manifests and metadata.
 	err := b.checkDiff()
 	if err != nil {
 		return err

--- a/build/buildkit/buildimage/shadow.go
+++ b/build/buildkit/buildimage/shadow.go
@@ -72,7 +72,7 @@ func (s ShadowPuller) Process(context, rootfs string) error {
 
 		ia[auth] = domainToImages
 	}
-	fmt.Println(ia)
+
 	if len(ia) == 0 {
 		return nil
 	}

--- a/build/buildkit/buildimage/shadow.go
+++ b/build/buildkit/buildimage/shadow.go
@@ -1,0 +1,88 @@
+// Copyright © 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildimage
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/alibaba/sealer/common"
+	"github.com/alibaba/sealer/pkg/image/save"
+	"github.com/alibaba/sealer/pkg/runtime"
+	"github.com/alibaba/sealer/utils"
+)
+
+var (
+	imageListWithAuth = "imageListWithAuth.yaml"
+)
+
+type Shadow interface {
+	// Process set data to cloud image ,but not to show in the image layer.
+	Process(context, rootfs string) error
+}
+
+type ShadowPuller struct {
+	puller save.DefaultImageSaver
+}
+
+func (s ShadowPuller) Process(context, rootfs string) error {
+	//read the filePath named "imageListWithAuth.yaml" if not exists just return;
+	//pares the images and save to rootfs
+	filePath := filepath.Join(context, imageListWithAuth)
+	if !utils.IsExist(filePath) {
+		return nil
+	}
+
+	// pares shadow file: imageListWithAuth.yaml
+	var imageSection []save.ImageSection
+	ia := make(save.ImageListWithAuth)
+
+	err := utils.UnmarshalYamlFile(filePath, &imageSection)
+	if err != nil {
+		return err
+	}
+
+	for _, section := range imageSection {
+		if len(section.Images) == 0 {
+			continue
+		}
+		if section.Username == "" || section.Password == "" {
+			return fmt.Errorf("must set username and password at imageListWithAuth.yaml")
+		}
+		auth, nameds, err := save.NewImageListWithAuth(section)
+		if err != nil {
+			return err
+		}
+		domainToImages := make(map[string][]save.Named)
+		for _, named := range nameds {
+			domainToImages[named.Domain()+named.Repo()] = append(domainToImages[named.Domain()+named.Repo()], named)
+		}
+
+		ia[auth] = domainToImages
+	}
+	fmt.Println(ia)
+	if len(ia) == 0 {
+		return nil
+	}
+
+	plat := runtime.GetCloudImagePlatform(rootfs)
+	return s.puller.SaveImagesWithAuth(ia, filepath.Join(rootfs, common.RegistryDirName), plat)
+}
+
+func NewShadowPuller() Shadow {
+	return ShadowPuller{
+		puller: save.DefaultImageSaver{},
+	}
+}

--- a/pkg/image/save/save_test.go
+++ b/pkg/image/save/save_test.go
@@ -58,7 +58,7 @@ func Test_splitDockerDomain(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if domain, remainer := splitDockerDomain(tt.imageName); domain != tt.wantDomain || remainer != tt.wantRemain {
+			if domain, remainer := splitDockerDomain(tt.imageName, ""); domain != tt.wantDomain || remainer != tt.wantRemain {
 				t.Errorf("split image %s error", tt.name)
 			}
 		})
@@ -112,7 +112,7 @@ func Test_parseNormalizedNamed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if named, err := parseNormalizedNamed(tt.imageName); err != nil || named.Domain() != tt.wantDomain || named.Repo() != tt.wantRepo || named.tag != tt.wantTag {
+			if named, err := parseNormalizedNamed(tt.imageName, ""); err != nil || named.Domain() != tt.wantDomain || named.Repo() != tt.wantRepo || named.tag != tt.wantTag {
 				t.Errorf("parse image %s error", tt.name)
 			}
 		})

--- a/pkg/image/save/util.go
+++ b/pkg/image/save/util.go
@@ -50,13 +50,18 @@ func (n Named) Tag() string {
 	return n.tag
 }
 
-func splitDockerDomain(name string) (domain, remainder string) {
+func splitDockerDomain(name string, registry string) (domain, remainder string) {
 	i := strings.IndexRune(name, '/')
 	if i == -1 || (!strings.ContainsAny(name[:i], ".:") && name[:i] != "localhost" && strings.ToLower(name[:i]) == name[:i]) {
-		domain, remainder = defaultDomain, name
+		if registry != "" {
+			domain, remainder = registry, name
+		} else {
+			domain, remainder = defaultDomain, name
+		}
 	} else {
 		domain, remainder = name[:i], name[i+1:]
 	}
+
 	if domain == legacyDefaultDomain {
 		domain = defaultDomain
 	}
@@ -66,8 +71,8 @@ func splitDockerDomain(name string) (domain, remainder string) {
 	return
 }
 
-func parseNormalizedNamed(s string) (Named, error) {
-	domain, remainder := splitDockerDomain(s)
+func parseNormalizedNamed(s string, registry string) (Named, error) {
+	domain, remainder := splitDockerDomain(s, registry)
 	var remoteName, tag string
 	if tagSep := strings.IndexRune(remainder, ':'); tagSep > -1 {
 		tag = remainder[tagSep+1:]

--- a/utils/docker_config.go
+++ b/utils/docker_config.go
@@ -69,6 +69,10 @@ func (d DockerInfo) DecodeDockerAuth(hostname string) (string, string, error) {
 		return "", "", fmt.Errorf("auth for %s doesn't exist", hostname)
 	}
 
+	return DecodeAuth(auth)
+}
+
+func DecodeAuth(auth string) (string, string, error) {
 	decode, err := base64.StdEncoding.DecodeString(auth)
 	if err != nil {
 		return "", "", err
@@ -76,7 +80,7 @@ func (d DockerInfo) DecodeDockerAuth(hostname string) (string, string, error) {
 
 	spts := strings.Split(string(decode), ":")
 	if len(spts) != 2 {
-		return "", "", fmt.Errorf("%s auth base64 has problem of format", hostname)
+		return "", "", fmt.Errorf("auth base64 has problem of format")
 	}
 
 	return spts[0], spts[1], nil
@@ -84,7 +88,7 @@ func (d DockerInfo) DecodeDockerAuth(hostname string) (string, string, error) {
 
 func SetDockerConfig(hostname, username, password string) error {
 	authFile := common.DefaultRegistryAuthConfigDir()
-	authEncode := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
+	authEncode := EncodeAuth(username, password)
 	var info *DockerInfo
 	var err error
 	if !IsFileExist(authFile) {
@@ -107,6 +111,10 @@ func SetDockerConfig(hostname, username, password string) error {
 		return fmt.Errorf("write %s failed,%s", authFile, err)
 	}
 	return nil
+}
+
+func EncodeAuth(username, password string) string {
+	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
 }
 
 func GetDockerAuthInfoFromDocker(domain string) (types.AuthConfig, error) {

--- a/utils/docker_config.go
+++ b/utils/docker_config.go
@@ -15,13 +15,13 @@
 package utils
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/docker/docker/api/types"
 
@@ -77,13 +77,13 @@ func DecodeAuth(auth string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
+	i := bytes.IndexRune(decode, ':')
 
-	spts := strings.Split(string(decode), ":")
-	if len(spts) != 2 {
+	if i == -1 {
 		return "", "", fmt.Errorf("auth base64 has problem of format")
 	}
 
-	return spts[0], spts[1], nil
+	return string(decode[:i]), string(decode[i+1:]), nil
 }
 
 func SetDockerConfig(hostname, username, password string) error {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

sealer build support multi-user logic to pull docker images

trigger: 

if build context contains file named at "imageListWithAuth.yaml",and its format like below, will trigger sealer build to pull docker images, its work process like `COPY imageList manifests`.

```yaml
- registry: registry.cn-shanghai.aliyuncs.com
  username: user1
  password: pw
  images:
    - registry.cn-shanghai.aliyuncs.com/xxx/xxx1:v1.1
    - registry.cn-shanghai.aliyuncs.com/xxx/xxx2:v1.1
- registry: registry.cn-shanghai.aliyuncs.com
  username: user2
  password: pw
  images:
    - registry.cn-shanghai.aliyuncs.com/xxx/xxx3:v1.1
    - registry.cn-shanghai.aliyuncs.com/xxx/xxx4:v1.1
```

 filed `registry` is optional , if not present will use the default "docker.io" as its domain name. if len (images)==0 will skip this section.

below is my build context: this will trigger pull images form `imageList` and `imageListWithAuth`

```shell
[root@iZbp16ikro46xwgqzij67sZ build]# ll
total 12
-rw-r--r-- 1 root root   7 Feb 28 14:10 imageList
-rw-r--r-- 1 root root 450 Mar  1 10:20 imageListWithAuth.yaml
-rw-r--r-- 1 root root  49 Feb 28 14:06 Kubefile
[root@iZbp16ikro46xwgqzij67sZ build]# 
[root@iZbp16ikro46xwgqzij67sZ build]# cat Kubefile 
FROM kubernetes:v1.19.8
COPY imageList manifests

```

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
