### PR TITLE
fix:remount registry of rootfs to cache images when cloud build

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -49,7 +49,7 @@ const (
 	YamlSuffix                    = ".yaml"
 	ImageAnnotationForClusterfile = "sea.aliyun.com/ClusterFile"
 	RawClusterfile                = "/var/lib/sealer/Clusterfile"
-	TmpClusterfile                = "/var/lib/sealer/tmp/Clusterfile"
+	TmpClusterfile                = "/tmp/Clusterfile"
 	DefaultRegistryHostName       = "registry.cn-qingdao.aliyuncs.com"
 	DefaultRegistryAuthDir        = "/root/.docker/config.json"
 	KubeAdminConf                 = "/etc/kubernetes/admin.conf"

--- a/common/common.go
+++ b/common/common.go
@@ -49,7 +49,7 @@ const (
 	YamlSuffix                    = ".yaml"
 	ImageAnnotationForClusterfile = "sea.aliyun.com/ClusterFile"
 	RawClusterfile                = "/var/lib/sealer/Clusterfile"
-	TmpClusterfile                = "/tmp/Clusterfile"
+	TmpClusterfile                = "/var/lib/sealer/tmp/Clusterfile"
 	DefaultRegistryHostName       = "registry.cn-qingdao.aliyuncs.com"
 	DefaultRegistryAuthDir        = "/root/.docker/config.json"
 	KubeAdminConf                 = "/etc/kubernetes/admin.conf"


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

collect operator images via remount registry.

because runtime apply registry not mount the rootfs/registry as lower layer. if we want to collect operator images, we must remount the dir rootfs/registry for collecting differ of the overlay upper layer.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
