### PR TITLE
nydus: fix an error about async in mountNydusRootfs

### DIFF
--- a/applications/nydus/nydusdfile/serverstart.sh
+++ b/applications/nydus/nydusdfile/serverstart.sh
@@ -18,8 +18,6 @@ set -x
 # create nydusimages
 ./nydus-image create --blob-dir ./nydusdimages/blobs  --bootstrap ./rootfs.meta $1
 #nydusdir need be scp
-rm -rf $2
-mkdir $2
 nydusdconfig='
 {\n
   "device": {\n
@@ -27,7 +25,7 @@ nydusdconfig='
       "type": "registry",\n
       "config": {\n
         "scheme": "http",\n
-        "host": "'${3}':8000",\n
+        "host": "'${2}':8000",\n
         "repo": "sealer"\n
       }\n
     },\n
@@ -50,8 +48,7 @@ nydusdconfig='
 }\n
 '
 echo -e ${nydusdconfig} > ./nydusd_scp_file/httpserver.json
-cp ./nydusd_scp_file/* $2
-cp ./rootfs.meta $2
+cp ./rootfs.meta ./nydusd_scp_file
 # nydusd_http_server.service
 service="[Unit]\n
 Description=sealer nydusd rootfs\n

--- a/pkg/filesystem/cloudfilesystem/nydus.go
+++ b/pkg/filesystem/cloudfilesystem/nydus.go
@@ -90,7 +90,8 @@ func mountNydusRootfs(ipList []string, target string, cluster *v2.Cluster, initF
 		src               = common.DefaultMountCloudImageDir(cluster.Name)
 		nydusdDir         = common.DefaultTheClusterNydusdDir(cluster.Name)
 		nydusdFileDir     = common.DefaultTheClusterNydusdFileDir(cluster.Name)
-		startNydusdServer = fmt.Sprintf("cd %s && chmod +x serverstart.sh && ./serverstart.sh %s %s %s", nydusdFileDir, src, nydusdDir, localIP)
+		nydusdSrcDir      = filepath.Join(nydusdFileDir, "nydusd_scp_file")
+		startNydusdServer = fmt.Sprintf("cd %s && chmod +x serverstart.sh && ./serverstart.sh %s %s", nydusdFileDir, src, localIP)
 		nydusdInitCmd     = fmt.Sprintf(RemoteNydusdInit, nydusdDir, target)
 		nydusdCleanCmd    = fmt.Sprintf(RemoteNydusdStop, filepath.Join(nydusdDir, "clean.sh"), nydusdDir)
 		cleanCmd          = fmt.Sprintf("echo '%s' >> "+common.DefaultClusterClearBashFile, nydusdCleanCmd, cluster.Name)
@@ -120,7 +121,7 @@ func mountNydusRootfs(ipList []string, target string, cluster *v2.Cluster, initF
 			if err != nil {
 				return fmt.Errorf("get host ssh client failed %v", err)
 			}
-			err = copyFiles(sshClient, ip == config.IP, ip, nydusdDir, nydusdDir)
+			err = copyFiles(sshClient, ip == config.IP, ip, nydusdSrcDir, nydusdDir)
 			if err != nil {
 				return fmt.Errorf("scp nydusd failed %v", err)
 			}


### PR DESCRIPTION

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
When the node running sealer is one of masters, the node maybe run
nydusdInitCmd before scp nydud dir to other nodes finish. It will
scp all files in rootfs because the nydusd src dir is the same as
target dir. So change the nydusd src dir to be different from nydusdDir.

### Does this pull request fix one issue?
NONE
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
