### PR TITLE
host env to overwrite global env, and list env is separated by a semicolon

### DIFF
--- a/docs/site/src/docs/advanced/use-clusterfile.md
+++ b/docs/site/src/docs/advanced/use-clusterfile.md
@@ -11,8 +11,7 @@ spec:
   image: kubernetes:v1.19.8
   env:
     - key1=value1
-    - key2=value2
-    - key2=value3 #key2=[value2, value3]
+    - key2=value2;value3 #key2=[value2, value3]
   ssh:
     passwd:
     pk: xxx
@@ -299,11 +298,13 @@ spec:
   image: kubernetes:v1.19.8
   env:
     - docker_dir=/var/lib/docker
+    - ips=192.168.0.1;192.168.0.2;192.168.0.3 #ips=[192.168.0.1 192.168.0.2 192.168.0.3]
   hosts:
     - ips: [ 192.168.0.2 ]
       roles: [ master ] # add role field to specify the node role
-      env: # overwrite some nodes has different env config
+      env: # overwrite some nodes has different env config, arrays are separated by semicolons
         - docker_dir=/data/docker
+        - ips=192.168.0.2;192.168.0.3
     - ips: [ 192.168.0.3 ]
       roles: [ node ]
 ```

--- a/docs/site/src/zh/getting-started/using-clusterfile.md
+++ b/docs/site/src/zh/getting-started/using-clusterfile.md
@@ -296,11 +296,13 @@ spec:
   image: kubernetes:v1.19.8
   env:
     - docker_dir=/var/lib/docker
+    - ips=192.168.0.1;192.168.0.2;192.168.0.3 #ips=[192.168.0.1 192.168.0.2 192.168.0.3]
   hosts:
     - ips: [ 192.168.0.2 ]
-      roles: [ master ] # add role field to specify the node role
-      env: # overwrite some nodes has different env config
+      roles: [ master ]
+      env: # 不同节点支持覆盖env，数组使用分号隔开
         - docker_dir=/data/docker
+        - ips=192.168.0.2;192.168.0.3
     - ips: [ 192.168.0.3 ]
       roles: [ node ]
 ```
@@ -309,11 +311,11 @@ spec:
 
 ```shell script
 #!/bin/bash
-echo $docker_dir
+echo $docker_dir ${ips[@]}
 ```
 
-当sealer执行脚本时env的设置类似于：`docker_dir=/data/docker && sh init.sh`
-In this case, master ENV is `/data/docker`, node ENV is by default `/var/lib/docker`
+当sealer执行脚本时env的设置类似于：`docker_dir=/data/docker ips=(192.168.0.2;192.168.0.3) && sh init.sh`
+该例子中, master ENV 是 `/data/docker`, node ENV 为 `/var/lib/docker`
 
 ### 支持Env渲染
 

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -33,8 +33,8 @@ func Test_convertEnv(t *testing.T) {
 	}{
 		{
 			"test convert env",
-			args{envList: []string{"IP=127.0.0.1", "IP=192.168.0.2", "key=value"}},
-			map[string]interface{}{"IP": []string{"127.0.0.1", "192.168.0.2"}, "key": "value"},
+			args{envList: []string{"IP=127.0.0.1;127.0.0.2;127.0.0.3", "IP=192.168.0.2", "key=value"}},
+			map[string]interface{}{"IP": []string{"127.0.0.1", "127.0.0.2", "127.0.0.3", "192.168.0.2"}, "key": "value"},
 		},
 	}
 	for _, tt := range tests {
@@ -84,7 +84,7 @@ func Test_processor_WrapperShell(t *testing.T) {
 				host:  "192.168.0.2",
 				shell: "echo $foo ${IP[@]}",
 			},
-			"key=(bar foo value) foo=bar IP=(127.0.0.2 127.0.0.1) && echo $foo ${IP[@]}",
+			"key=(bar foo) foo=bar IP=127.0.0.2 && echo $foo ${IP[@]}",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
host env to overwrite global env;
list env is separated by a semicolon

```shell
  env:
    - docker_dir=/var/lib/docker
    - ips=192.168.0.1;192.168.0.2;192.168.0.3 #ips=[192.168.0.1 192.168.0.2 192.168.0.3]
  hosts:
    - ips: [ 192.168.0.2 ]
      roles: [ master ] # add role field to specify the node role
      env: # overwrite some nodes has different env config, arrays are separated by semicolons
        - docker_dir=/data/docker
        - ips=192.168.0.2;192.168.0.3
```