### PR TITLE
change to kubeadm V1beta3 when k8s verison gt 1.23.0

### DIFF
--- a/pkg/runtime/kubeadm.go
+++ b/pkg/runtime/kubeadm.go
@@ -35,20 +35,13 @@ echo ${driver}`
 // k.getKubeVersion can't be empty
 func (k *KubeadmRuntime) setKubeadmAPIVersion() {
 	switch {
-	case VersionCompare(k.getKubeVersion(), V1150) && !VersionCompare(k.getKubeVersion(), V1200):
-		k.InitConfiguration.APIVersion = KubeadmV1beta2
-		k.ClusterConfiguration.APIVersion = KubeadmV1beta2
-		k.JoinConfiguration.APIVersion = KubeadmV1beta2
-	// kubernetes gt 1.20, use Containerd instead of docker
-	case VersionCompare(k.getKubeVersion(), V1200):
-		k.InitConfiguration.APIVersion = KubeadmV1beta2
-		k.ClusterConfiguration.APIVersion = KubeadmV1beta2
-		k.JoinConfiguration.APIVersion = KubeadmV1beta2
+	case VersionCompare(k.getKubeVersion(), V1150) && !VersionCompare(k.getKubeVersion(), V1230):
+		k.setAPIVersion(KubeadmV1beta2)
+	case VersionCompare(k.getKubeVersion(), V1230):
+		k.setAPIVersion(KubeadmV1beta3)
 	default:
 		// Compatible with versions 1.14 and 1.13. but do not recommended.
-		k.InitConfiguration.APIVersion = KubeadmV1beta1
-		k.ClusterConfiguration.APIVersion = KubeadmV1beta1
-		k.JoinConfiguration.APIVersion = KubeadmV1beta1
+		k.setAPIVersion(KubeadmV1beta1)
 	}
 }
 

--- a/pkg/runtime/kubeadm_runtime.go
+++ b/pkg/runtime/kubeadm_runtime.go
@@ -230,6 +230,11 @@ func (k *KubeadmRuntime) setCgroupDriver(cGroup string) {
 	k.KubeletConfiguration.CgroupDriver = cGroup
 }
 
+func (k *KubeadmRuntime) setAPIVersion(apiVersion string) {
+	k.InitConfiguration.APIVersion = apiVersion
+	k.ClusterConfiguration.APIVersion = apiVersion
+	k.JoinConfiguration.APIVersion = apiVersion
+}
 func getEtcdEndpointsWithHTTPSPrefix(masters []string) string {
 	var tmpSlice []string
 	for _, ip := range masters {


### PR DESCRIPTION
change to kubeadm V1beta3 when k8s verison gt 1.23.0