### PR TITLE
fix vuepress error

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,25 @@
+name: Site
+
+on:
+  push:
+    branches: "*"
+    paths:
+      - "docs/site/**"
+  pull_request:
+    branches: "*"
+    paths:
+      - "docs/site/**"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: npm install
+        working-directory: docs/site
+      - name: Static website hosting
+        run: npm run build
+        working-directory: docs/site

--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -8,3 +8,5 @@ How to build static files:
 npm run build
 cd .vuepress/dist
 ```
+
+Vuepress syntax error will cause the failure of building. [docs](https://vuepress.vuejs.org/guide/using-vue.html)

--- a/docs/site/src/zh/getting-started/using-clusterfile.md
+++ b/docs/site/src/zh/getting-started/using-clusterfile.md
@@ -419,4 +419,6 @@ spec:
           cidr: {{ .podcidr }}
 ```
 
+::: v-pre
 kubeadm和calico配置中的`{{ .podcidr }}`将被替换为Clusterfile.Env中的`podcidr`。
+:::


### PR DESCRIPTION
Incorrect use of '{{}}' caused the vuepress build to fail: https://github.com/alibaba/sealer/runs/5593882562?check_suite_focus=true

when changing site documentation, perform the 'npm run build' step to prevent site updates from failing because of the change.