### PR TITLE
feat: ssh passwd in clusterfile encrypt(#1201)

### DIFF
--- a/types/api/v1/cluster_types.go
+++ b/types/api/v1/cluster_types.go
@@ -19,11 +19,12 @@ import (
 )
 
 type SSH struct {
-	User     string `json:"user,omitempty"`
-	Passwd   string `json:"passwd,omitempty"`
-	Pk       string `json:"pk,omitempty"`
-	PkPasswd string `json:"pkPasswd,omitempty"`
-	Port     string `json:"port,omitempty"`
+	Encrypted bool   `json:"encrypted,omitempty"`
+	User      string `json:"user,omitempty"`
+	Passwd    string `json:"passwd,omitempty"`
+	Pk        string `json:"pk,omitempty"`
+	PkPasswd  string `json:"pkPasswd,omitempty"`
+	Port      string `json:"port,omitempty"`
 }
 
 type Network struct {

--- a/utils/aes.go
+++ b/utils/aes.go
@@ -1,0 +1,84 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/alibaba/sealer/logger"
+)
+
+const aesKey = "ZU9WbzRMVXRQZ2pzTGowR2hNWUpIZjRkWld4aWVRWko="
+
+func AesEncrypt(origData []byte) (string, error) {
+	key, err := base64.StdEncoding.DecodeString(aesKey)
+	if err != nil {
+		logger.Error("key base64 decode failed")
+		return "", err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	blockSize := block.BlockSize()
+	origData = pkcs7Padding(origData, blockSize)
+	blockMode := cipher.NewCBCEncrypter(block, key[:blockSize])
+	ciphertext := make([]byte, len(origData))
+	blockMode.CryptBlocks(ciphertext, origData)
+	return base64.StdEncoding.EncodeToString(ciphertext), nil
+}
+
+func AesDecrypt(ciphertext []byte) (string, error) {
+	key, err := base64.StdEncoding.DecodeString(aesKey)
+	if err != nil {
+		logger.Error("key base64 decode failed")
+		return "", err
+	}
+	ciphertext, err = base64.StdEncoding.DecodeString(string(ciphertext))
+	if err != nil {
+		logger.Error("ciphertext base64 decode failed")
+		return "", err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	blockSize := block.BlockSize()
+	if len(ciphertext) < blockSize {
+		return "", fmt.Errorf("ciphertext short than block size")
+	}
+
+	plaintext := make([]byte, len(ciphertext))
+	mode := cipher.NewCBCDecrypter(block, key[:blockSize])
+	mode.CryptBlocks(plaintext, ciphertext)
+	plaintext = pkcs7UnPadding(plaintext)
+	return string(plaintext), nil
+}
+
+func pkcs7Padding(origData []byte, blockSize int) []byte {
+	padding := blockSize - len(origData)%blockSize
+	padText := bytes.Repeat([]byte{byte(padding)}, padding)
+	return append(origData, padText...)
+}
+
+func pkcs7UnPadding(origData []byte) []byte {
+	length := len(origData)
+	unPadding := int(origData[length-1])
+	return origData[:(length - unPadding)]
+}

--- a/utils/ssh/connect.go
+++ b/utils/ssh/connect.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/alibaba/sealer/utils"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -32,6 +33,14 @@ import (
 const DefaultSSHPort = "22"
 
 func (s *SSH) connect(host string) (*ssh.Client, error) {
+	if s.Encrypted {
+		passwd, err := utils.AesDecrypt([]byte(s.Password))
+		if err != nil {
+			return nil, err
+		}
+		s.Password = passwd
+		s.Encrypted = false
+	}
 	auth := s.sshAuthMethod(s.Password, s.PkFile, s.PkPassword)
 	config := ssh.Config{
 		Ciphers: []string{"aes128-ctr", "aes192-ctr", "aes256-ctr", "aes128-gcm@openssh.com", "arcfour256", "arcfour128", "aes128-cbc", "3des-cbc", "aes192-cbc", "aes256-cbc"},

--- a/utils/ssh/ssh.go
+++ b/utils/ssh/ssh.go
@@ -53,6 +53,7 @@ type Interface interface {
 
 type SSH struct {
 	isStdout     bool
+	Encrypted    bool
 	User         string
 	Password     string
 	Port         string
@@ -71,6 +72,7 @@ func NewSSHByCluster(cluster *v1.Cluster) Interface {
 		logger.Warn("failed to get local address, %v", err)
 	}
 	return &SSH{
+		Encrypted:    cluster.Spec.SSH.Encrypted,
 		User:         cluster.Spec.SSH.User,
 		Password:     cluster.Spec.SSH.Passwd,
 		Port:         cluster.Spec.SSH.Port,
@@ -90,6 +92,7 @@ func NewSSHClient(ssh *v1.SSH, isStdout bool) Interface {
 	}
 	return &SSH{
 		isStdout:     isStdout,
+		Encrypted:    ssh.Encrypted,
 		User:         ssh.User,
 		Password:     ssh.Passwd,
 		Port:         ssh.Port,

--- a/utils/ssh/sshcmd_test.go
+++ b/utils/ssh/sshcmd_test.go
@@ -34,6 +34,7 @@ func TestSSH_Cmd(t *testing.T) {
 			name: "touch test.txt",
 			args: args{
 				ssh: SSH{false,
+					false,
 					"root",
 					"huaijiahui.com",
 					"",
@@ -52,6 +53,7 @@ func TestSSH_Cmd(t *testing.T) {
 			name: "ls /opt/test",
 			args: args{
 				ssh: SSH{false,
+					false,
 					"root",
 					"huaijiahui.com",
 					"",
@@ -70,6 +72,7 @@ func TestSSH_Cmd(t *testing.T) {
 			name: "remove test.txt",
 			args: args{
 				ssh: SSH{false,
+					false,
 					"root",
 					"huaijiahui.com",
 					"",
@@ -88,6 +91,7 @@ func TestSSH_Cmd(t *testing.T) {
 			name: "exist 1",
 			args: args{
 				ssh: SSH{false,
+					false,
 					"root",
 					"huaijiahui.com",
 					"",
@@ -133,6 +137,7 @@ func TestSSH_CmdAsync(t *testing.T) {
 			name: "touch test.txt",
 			args: args{
 				ssh: SSH{false,
+					false,
 					"root",
 					"huaijiahui.com",
 					"",
@@ -150,6 +155,7 @@ func TestSSH_CmdAsync(t *testing.T) {
 			name: "ls /opt/test",
 			args: args{
 				ssh: SSH{false,
+					false,
 					"root",
 					"huaijiahui.com",
 					"",
@@ -167,6 +173,7 @@ func TestSSH_CmdAsync(t *testing.T) {
 			name: "remove test.txt",
 			args: args{
 				ssh: SSH{false,
+					false,
 					"root",
 					"huaijiahui.com",
 					"",
@@ -184,6 +191,7 @@ func TestSSH_CmdAsync(t *testing.T) {
 			name: "exist 1",
 			args: args{
 				ssh: SSH{false,
+					false,
 					"root",
 					"huaijiahui.com",
 					"",


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
The plaintext password in Clusterfile is insecure. Use AES to entrypt it.

### Does this pull request fix one issue?

Fixes #1201 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it
sealer run kubernetes:v1.19.8 --masters 10.0.71.100 --passwd xxxx
sealer delete --all --force

### Special notes for reviews
As my test environment imit. I only test with run and delete.

