### PR TITLE
support multi arch run

### DIFF
--- a/apply/processor/create.go
+++ b/apply/processor/create.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	v1 "github.com/alibaba/sealer/types/api/v1"
+	"github.com/alibaba/sealer/utils/ssh"
 
 	"github.com/alibaba/sealer/utils/platform"
 
@@ -91,8 +92,16 @@ func (c *CreateProcessor) GetPipeLine() ([]func(cluster *v2.Cluster) error, erro
 
 func (c *CreateProcessor) MountImage(cluster *v2.Cluster) error {
 	//todo need to filter image by platform
+	platsMap, err := ssh.GetClusterPlatform(cluster)
+	if err != nil {
+		return err
+	}
 	plats := []*v1.Platform{platform.GetDefaultPlatform()}
-	err := c.ImageManager.PullIfNotExist(cluster.Spec.Image, plats)
+	for _, v := range platsMap {
+		plat := v
+		plats = append(plats, &plat)
+	}
+	err = c.ImageManager.PullIfNotExist(cluster.Spec.Image, plats)
 	if err != nil {
 		return err
 	}

--- a/apply/run.go
+++ b/apply/run.go
@@ -71,6 +71,9 @@ func PreProcessIPList(joinArgs *common.RunArgs) error {
 }
 
 func (c *ClusterArgs) SetClusterArgs() error {
+	c.cluster.APIVersion = common.APIVersion
+	c.cluster.Kind = common.Cluster
+	c.cluster.Name = c.runArgs.ClusterName
 	c.cluster.Spec.Image = c.imageName
 	c.cluster.Spec.SSH.User = c.runArgs.User
 	c.cluster.Spec.SSH.Pk = c.runArgs.Pk
@@ -145,15 +148,8 @@ func GetClusterFileByImageName(imageName string) (*v2.Cluster, error) {
 }
 
 func NewApplierFromArgs(imageName string, runArgs *common.RunArgs) (applydriver.Interface, error) {
-	cluster, err := GetClusterFileByImageName(imageName)
-	if err != nil {
-		return nil, err
-	}
-	if runArgs.Nodes == "" && runArgs.Masters == "" {
-		return NewApplier(cluster)
-	}
 	c := &ClusterArgs{
-		cluster:   cluster,
+		cluster:   &v2.Cluster{},
 		imageName: imageName,
 		runArgs:   runArgs,
 	}

--- a/common/structs.go
+++ b/common/structs.go
@@ -15,16 +15,17 @@
 package common
 
 type RunArgs struct {
-	Masters    string
-	Nodes      string
-	User       string
-	Password   string
-	Port       uint16
-	Pk         string
-	PkPassword string
-	PodCidr    string
-	SvcCidr    string
-	Provider   string
-	CustomEnv  []string
-	CMDArgs    []string
+	ClusterName string
+	Masters     string
+	Nodes       string
+	User        string
+	Password    string
+	Port        uint16
+	Pk          string
+	PkPassword  string
+	PodCidr     string
+	SvcCidr     string
+	Provider    string
+	CustomEnv   []string
+	CMDArgs     []string
 }

--- a/pkg/filesystem/cloudfilesystem/nydus.go
+++ b/pkg/filesystem/cloudfilesystem/nydus.go
@@ -102,12 +102,6 @@ func mountNydusRootfs(ipList []string, target string, cluster *v2.Cluster, initF
 		initCmd           = fmt.Sprintf(RemoteChmod, target, config.Domain, config.Port)
 	)
 
-	// use env list to render image mount dir: etc,charts,manifests.
-	err = renderENV(src, ipList, envProcessor)
-	if err != nil {
-		return err
-	}
-
 	//convert image and start nydusd http server
 	_, err = utils.RunSimpleCmd(startNydusdServer)
 	if err != nil {

--- a/pkg/filesystem/cloudfilesystem/utils.go
+++ b/pkg/filesystem/cloudfilesystem/utils.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 
 	"github.com/alibaba/sealer/common"
-	"github.com/alibaba/sealer/pkg/env"
 	"github.com/alibaba/sealer/utils"
 	"github.com/alibaba/sealer/utils/ssh"
 )
@@ -41,26 +40,6 @@ func copyFiles(sshEntry ssh.Interface, isRegistry bool, ip, src, target string) 
 		err = sshEntry.Copy(ip, filepath.Join(src, f.Name()), filepath.Join(target, f.Name()))
 		if err != nil {
 			return fmt.Errorf("failed to copy sub files %v", err)
-		}
-	}
-	return nil
-}
-
-func renderENV(imageMountDir string, ipList []string, p env.Interface) error {
-	var (
-		renderEtc       = filepath.Join(imageMountDir, common.EtcDir)
-		renderChart     = filepath.Join(imageMountDir, common.RenderChartsDir)
-		renderManifests = filepath.Join(imageMountDir, common.RenderManifestsDir)
-	)
-
-	for _, ip := range ipList {
-		for _, dir := range []string{renderEtc, renderChart, renderManifests} {
-			if utils.IsExist(dir) {
-				err := p.RenderAll(ip, dir)
-				if err != nil {
-					return err
-				}
-			}
 		}
 	}
 	return nil

--- a/pkg/guest/guest.go
+++ b/pkg/guest/guest.go
@@ -17,6 +17,7 @@ package guest
 import (
 	"fmt"
 
+	"github.com/alibaba/sealer/pkg/runtime"
 	"github.com/alibaba/sealer/utils/platform"
 
 	v1 "github.com/alibaba/sealer/types/api/v1"
@@ -25,7 +26,6 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
 
-	"github.com/alibaba/sealer/pkg/runtime"
 	v2 "github.com/alibaba/sealer/types/api/v2"
 
 	"github.com/alibaba/sealer/common"
@@ -78,7 +78,7 @@ func (d *Default) Apply(cluster *v2.Cluster) error {
 			return fmt.Errorf("failed to render build args: %v", err)
 		}
 
-		if err := sshClient.CmdAsync(runtime.GetMaster0Ip(cluster), fmt.Sprintf(common.CdAndExecCmd, clusterRootfs, cmdline)); err != nil {
+		if err := sshClient.CmdAsync(cluster.GetMaster0IP(), fmt.Sprintf(common.CdAndExecCmd, clusterRootfs, cmdline)); err != nil {
 			return err
 		}
 	}

--- a/pkg/runtime/init.go
+++ b/pkg/runtime/init.go
@@ -277,7 +277,7 @@ func (k *KubeadmRuntime) GetKubectlAndKubeconfig() error {
 		return fmt.Errorf("failed to get master0 ssh client when get kubbectl and kubeconfig %v", err)
 	}
 
-	return GetKubectlAndKubeconfig(ssh, k.GetMaster0IP())
+	return GetKubectlAndKubeconfig(ssh, k.GetMaster0IP(), k.getImageMountDir())
 }
 
 func (k *KubeadmRuntime) CopyStaticFilesTomasters() error {

--- a/sealer/cmd/run.go
+++ b/sealer/cmd/run.go
@@ -70,6 +70,7 @@ func init() {
 	runCmd.Flags().StringVarP(&runArgs.Provider, "provider", "", "", "set infra provider, example `ALI_CLOUD`, the local server need ignore this")
 	runCmd.Flags().StringVarP(&runArgs.Masters, "masters", "m", "", "set Count or IPList to masters")
 	runCmd.Flags().StringVarP(&runArgs.Nodes, "nodes", "n", "", "set Count or IPList to nodes")
+	runCmd.Flags().StringVar(&runArgs.ClusterName, "cluster-name", "my-cluster", "set cluster name")
 	runCmd.Flags().StringVarP(&runArgs.User, "user", "u", "root", "set baremetal server username")
 	runCmd.Flags().StringVarP(&runArgs.Password, "passwd", "p", "", "set cloud provider or baremetal server password")
 	runCmd.Flags().Uint16Var(&runArgs.Port, "port", 22, "set the sshd service port number for the server (default port: 22)")

--- a/utils/platform/cpu.go
+++ b/utils/platform/cpu.go
@@ -49,7 +49,7 @@ func cpuVariant() string {
 				logger.Error(err)
 			}
 			model, err := getCPUInfo("model name")
-			if err != nil {
+			if !strings.Contains(err.Error(), ErrNotFound.Error()) {
 				logger.Error(err)
 			}
 			cpuVariantValue = GetCPUVariantByInfo(runtime.GOOS, runtime.GOARCH, variant, model)

--- a/utils/ssh/platform.go
+++ b/utils/ssh/platform.go
@@ -17,7 +17,6 @@ package ssh
 import (
 	"bufio"
 	"fmt"
-	"runtime"
 	"strings"
 
 	"github.com/alibaba/sealer/logger"
@@ -51,7 +50,7 @@ func (s *SSH) Platform(host string) (v1.Platform, error) {
 		return p, fmt.Errorf("unrecognized architecture：%s", archResult)
 	}
 	if p.Architecture != platform.AMD {
-		p.Variant, err = s.getCPUVariant(host)
+		p.Variant, err = s.getCPUVariant(p.OS, p.Architecture, host)
 		if err != nil {
 			return p, err
 		}
@@ -99,7 +98,7 @@ func (s *SSH) getCPUInfo(host, pattern string) (info string, err error) {
 	return "", errors.Wrapf(platform.ErrNotFound, "getCPUInfo for pattern: %s", pattern)
 }
 
-func (s *SSH) getCPUVariant(host string) (string, error) {
+func (s *SSH) getCPUVariant(os, arch, host string) (string, error) {
 	variant, err := s.getCPUInfo(host, "Cpu architecture")
 	if err != nil {
 		return "", err
@@ -111,7 +110,7 @@ func (s *SSH) getCPUVariant(host string) (string, error) {
 		}
 	}
 	variant, model = platform.NormalizeArch(variant, model)
-	return platform.GetCPUVariantByInfo(runtime.GOOS, runtime.GOARCH, variant, model), nil
+	return platform.GetCPUVariantByInfo(os, arch, variant, model), nil
 }
 
 func GetClusterPlatform(cluster *v2.Cluster) (map[string]v1.Platform, error) {


### PR DESCRIPTION
- pull images of all required architecture when apply;
- Fix failure of config for multiple arch;
- Move render env to mount images step;
- run creates new cluster information instead of using the cluster info of the clusterfile in the image;
- run command use `--cluster-name` to set cluster name;
- apply must support the local architecture，because of multiple architectures, the kubectl of fetch cannot be executed. It is - modified to obtain it from 'rootfs/bin/kubectl';
- fix a little bug.
