### PR TITLE
support sprig template function for GO's template

### DIFF
--- a/docs/site/src/docs/getting-started/using-clusterfile.md
+++ b/docs/site/src/docs/getting-started/using-clusterfile.md
@@ -321,6 +321,7 @@ In this case, master ENV is `/data/docker`, node ENV is by default `/var/lib/doc
 
 ### Env render support
 
+support [sprig](http://masterminds.github.io/sprig/) template functions.
 This case show you how to use env to set dashboard service target port
 
 dashboard.yaml.tmpl:

--- a/docs/site/src/zh/getting-started/using-clusterfile.md
+++ b/docs/site/src/zh/getting-started/using-clusterfile.md
@@ -319,6 +319,7 @@ echo $docker_dir ${ips[@]}
 
 ### 支持Env渲染
 
+支持[sprig](http://masterminds.github.io/sprig/) 模版函数。
 本案例展示如何使用 env 设置dashboard服务目标端口
 
 dashboard.yaml.tmpl:

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
+	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/aliyun/alibaba-cloud-sdk-go v1.61.985
 	github.com/cavaliergopher/grab/v3 v3.0.1
 	github.com/distribution/distribution/v3 v3.0.0-20211125133600-cc4627fc6e5f

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Masterminds/sprig/v3"
+
 	v2 "github.com/alibaba/sealer/types/api/v2"
 )
 
@@ -77,7 +79,7 @@ func (p *processor) RenderAll(host, dir string) error {
 		defer func() {
 			_ = writer.Close()
 		}()
-		t, err := template.ParseFiles(path)
+		t, err := template.New(info.Name()).Funcs(sprig.FuncMap()).ParseFiles(path)
 		if err != nil {
 			return fmt.Errorf("failed to create template: %s %v", path, err)
 		}

--- a/pkg/env/test/template/test.yaml.tmpl
+++ b/pkg/env/test/template/test.yaml.tmpl
@@ -1,2 +1,6 @@
 {{ .foo }}
 {{ .IP }}
+{{b64enc "qwertyuiop"}}
+{{b64dec "cXdlcnR5dWlvcA=="}}
+{{b64enc .IP}}
+{{b64enc .foo}}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,6 +9,7 @@ github.com/Masterminds/goutils
 ## explicit
 github.com/Masterminds/semver/v3
 # github.com/Masterminds/sprig/v3 v3.2.2
+## explicit
 github.com/Masterminds/sprig/v3
 # github.com/Microsoft/go-winio v0.4.17
 github.com/Microsoft/go-winio


### PR DESCRIPTION
[sprig template function for GO's template](http://masterminds.github.io/sprig/)

base64 encode or base64 decode:
```yaml
{{b64enc "qwertyuiop"}}
{{b64dec "cXdlcnR5dWlvcA=="}}
{{b64enc .IP}}
```