### PR TITLE
bugfix: add different  flag for upgrade drain cmd via k8s version

### DIFF
--- a/pkg/runtime/upgrade.go
+++ b/pkg/runtime/upgrade.go
@@ -50,7 +50,7 @@ func (k *KubeadmRuntime) upgrade() error {
 }
 
 func (k *KubeadmRuntime) upgradeFirstMaster(IP string, binpath, version string) error {
-	drain := drainCmd
+	var drain string
 	//if version >= 1.20.x,add flag `--delete-emptydir-data`
 	if VersionCompare(version, V1200) {
 		drain = fmt.Sprintf("%s %s", drainCmd, "--delete-emptydir-data")
@@ -74,7 +74,7 @@ func (k *KubeadmRuntime) upgradeFirstMaster(IP string, binpath, version string) 
 }
 
 func (k *KubeadmRuntime) upgradeOtherMasters(IPs []string, binpath, version string) error {
-	drain := drainCmd
+	var drain string
 	//if version >= 1.20.x,add flag `--delete-emptydir-data`
 	if VersionCompare(version, V1200) {
 		drain = fmt.Sprintf("%s %s", drainCmd, "--delete-emptydir-data")

--- a/pkg/runtime/upgrade.go
+++ b/pkg/runtime/upgrade.go
@@ -38,7 +38,7 @@ func (k *KubeadmRuntime) upgrade() error {
 	if err != nil {
 		return err
 	}
-	err = k.upgradeOtherMasters(k.GetMasterIPList()[1:], binpath)
+	err = k.upgradeOtherMasters(k.GetMasterIPList()[1:], binpath, k.getKubeVersion())
 	if err != nil {
 		return err
 	}
@@ -50,10 +50,18 @@ func (k *KubeadmRuntime) upgrade() error {
 }
 
 func (k *KubeadmRuntime) upgradeFirstMaster(IP string, binpath, version string) error {
+	drain := drainCmd
+	//if version >= 1.20.x,add flag `--delete-emptydir-data`
+	if VersionCompare(version, V1200) {
+		drain = fmt.Sprintf("%s %s", drainCmd, "--delete-emptydir-data")
+	} else {
+		drain = fmt.Sprintf("%s %s", drainCmd, "--delete-local-data")
+	}
+
 	var firstMasterCmds = []string{
 		fmt.Sprintf(chmodCmd, binpath),
 		fmt.Sprintf(mvCmd, binpath),
-		drainCmd,
+		drain,
 		fmt.Sprintf(upgradeCmd, strings.Join([]string{`apply`, version, `-y`}, " ")),
 		restartCmd,
 		uncordonCmd,
@@ -65,11 +73,19 @@ func (k *KubeadmRuntime) upgradeFirstMaster(IP string, binpath, version string) 
 	return ssh.CmdAsync(IP, firstMasterCmds...)
 }
 
-func (k *KubeadmRuntime) upgradeOtherMasters(IPs []string, binpath string) error {
+func (k *KubeadmRuntime) upgradeOtherMasters(IPs []string, binpath, version string) error {
+	drain := drainCmd
+	//if version >= 1.20.x,add flag `--delete-emptydir-data`
+	if VersionCompare(version, V1200) {
+		drain = fmt.Sprintf("%s %s", drainCmd, "--delete-emptydir-data")
+	} else {
+		drain = fmt.Sprintf("%s %s", drainCmd, "--delete-local-data")
+	}
+
 	var otherMasterCmds = []string{
 		fmt.Sprintf(chmodCmd, binpath),
 		fmt.Sprintf(mvCmd, binpath),
-		drainCmd,
+		drain,
 		fmt.Sprintf(upgradeCmd, `node`),
 		restartCmd,
 		uncordonCmd,


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

sealer run kubernetes:v1.19.8 with app empty dir ,like dashboard,   

if want to upgrade to kubernetes:v1.19.9: `kubectl drain --ignore-daemonsets  --delete-local-data`
if want to upgrade to kubernetes:v1.20.4: `kubectl drain --ignore-daemonsets --delete-emptydir-data`



### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
